### PR TITLE
merge qstat.cfg from the XQF project

### DIFF
--- a/qstat.cfg
+++ b/qstat.cfg
@@ -149,7 +149,7 @@ gametype WAWS new extend Q3S
     game rule = gametype
 end
 
-# enemy territory
+# id Tech 3 (Enemy Territory flavour)
 gametype WOETS new extend Q3S
     name = Enemy Territory
     template var = ENEMYTERRITORY
@@ -160,6 +160,20 @@ gametype WOETM new extend Q3M
     template var = WOETSMASTER
     master protocol = 84
     master for gametype = WOETS
+    master query =
+end
+
+# id Tech 3 (Enemy Territory: Legacy fork)
+gametype ETLS new extend Q3S
+    name = Enemy Territory: Legacy
+    template var = ETL
+    game rule = gamename
+end
+gametype ETLM new extend Q3M
+    name = Enemy Territory: Legacy Master
+    template var = ETLMASTER
+    master protocol = 84
+    master for gametype = ETLS
     master query =
 end
 
@@ -196,9 +210,11 @@ gametype UT2004M modify
     master for gametype = UT2004S
 end
 
+# id Tech 2 fork (DarkPlace engine, Quake 2 derivative)
 gametype NEXUIZS new extend Q3S
     name = Nexuiz
     template var = NEXUIZ
+    default port = 26000
     game rule = gamename
 end
 gametype NEXUIZM new extend Q3M
@@ -211,10 +227,28 @@ gametype NEXUIZM new extend Q3M
     master for gametype = NEXUIZS
 end
 
+# id Tech 2 fork (DarkPlace engine, Quake 2 derivative)
+gametype XONOTICS new extend Q3S
+    name = Xonotic
+    template var = XONOTIC
+    default port = 26000
+    game rule = gamename
+end
+gametype XONOTICM new extend Q3M
+    name = Xonotic Master
+    template var = XONOTICMASTER
+    default port = 27950
+    master packet = \377\377\377\377getservers Xonotic %s %s
+    master protocol = 3
+    master query = empty full
+    master for gametype = XONOTICS
+end
+
+# id Tech 2 fork (Qfusion engine, Quake 1 derivative)
 gametype WARSOWS new extend Q2S
     name = Warsow
-    default port = 44400
     template var = WARSOW
+    default port = 44400
     game rule = gamename
     status packet = \377\377\377\377getinfo
     status2 packet = \377\377\377\377getstatus
@@ -229,9 +263,10 @@ gametype WARSOWM new extend Q3M
     master for gametype = WARSOWS
 end
 
-gametype TREMULOUS new extend Q3S
+# id Tech 3 fork (Tremulous engine, Quake 3 derivative)
+gametype TREMULOUSS new extend Q3S
     name = Tremulous
-    template var = TREMULOUS
+    template var = TREMULOUSS
     game rule = gamename
 end
 gametype TREMULOUSM new extend Q3M
@@ -239,7 +274,51 @@ gametype TREMULOUSM new extend Q3M
     template var = TREMULOUSMASTER
     default port = 30710
     master protocol = 69
-    master for gametype = TREMULOUS
+    master for gametype = TREMULOUSS
+end
+
+# id Tech 3 fork (Tremulous engine derivative, Quake 3 derivative)
+gametype TREMULOUSGPPS new extend Q3S
+    name = Tremulous GPP
+    template var = TREMULOUSGPPS
+    game rule = gamename
+end
+gametype TREMULOUSGPPM new extend Q3M
+    name = Tremulous GPP Master
+    template var = TREMULOUSGPPMASTER
+    default port = 30700
+    master protocol = 70
+    master for gametype = TREMULOUSGPPS
+end
+
+# id Tech 3 fork (Tremulous engine derivative, Quake 3 derivative)
+gametype TREMFUSIONS new extend Q3S
+    name = TremFusion
+    template var = TREMFUSIONS
+    game rule = gamename
+end
+gametype TREMFUSIONM new extend Q3M
+    name = TremFusion Master
+    template var = TREMFUSIONMASTER
+    default port = 30710
+    master protocol = 69
+    master for gametype = TREMFUSIONS
+end
+
+# id Tech 3 fork (Daemon engine, Quake 3 derivative, via Tremulous, ioquake3, XreaL, ioWolfET)
+gametype UNVANQUISHEDS new extend Q3S
+    name = Unvanquished
+    template var = UNVANQUISHED
+    default port = 27960
+    status packet = \xff\xff\xff\xffgetstatus
+    game rule = gamename
+end
+gametype UNVANQUISHEDM new extend Q3M
+    name = Unvanquished Master
+    template var = UNVANQUISHEDMASTER
+    default port = 27950
+    master protocol = 86
+    master for gametype = UNVANQUISHEDS
 end
 
 gametype HLA2S new extend A2S
@@ -259,14 +338,28 @@ gametype PREYM new extend DM3M
     master for gametype = PREYS
 end
 
+gametype JK2S new extend Q3S
+	name = Jedi Knight 2
+	default port = 28070
+	template var = JEDIKNIGHT2
+	game rule = gamename
+end
+
+gametype JK2M new extend JK3M
+	name = Jedi Knight 2
+	default port = 28060
+	template var = JK2MASTER
+	master protocol = 16
+	master for gametype = JK2S
+end
+
 gametype UT3S new extend GS4
     name = UT3
     default port = 6500
     template var = UT3
 end
 
-
-# ioq3 fork
+# id Tech 3 fork (ioquake3 engine, Quake 3 derivative)
 gametype OPENARENAS new extend Q3S
     name = OpenArena
     template var = OPENARENA
@@ -283,19 +376,138 @@ gametype OPENARENAM new extend Q3M
     master for gametype = OPENARENAS
 end
 
-# ioq3 fork
+# id Tech 3 fork (ioquake3 engine, Quake 3 derivative)
+gametype Q3RALLYS new extend Q3S
+    name = Q3 Rally
+    template var = Q3RALLY
+    game rule = gamename
+end
+
+gametype Q3RALLYM new extend Q3M
+    name = Q3 Rally Master
+    template var = Q3RALLYMASTER
+    default port = 27950
+    master packet = \377\377\377\377getservers %s %s
+    master protocol = 71
+    master query = empty full
+    master for gametype = Q3RALLYS
+end
+
+# id Tech 3 fork (ioquake3 engine, Quake 3 derivative)
+gametype WOPS new extend Q3S
+    name = World Of Padman
+    template var = WOP
+    game rule = gamename
+end
+
+gametype WOPM new extend Q3M
+    name = World Of Padman Master
+    template var = WOPMASTER
+    default port = 27955
+    master packet = \377\377\377\377getservers WorldofPadman %s %s
+    master protocol = 71
+    master query = empty full
+    master for gametype = WOPS
+end
+
+# id Tech 3 fork (ioquake3 engine, Quake 3 derivative)
 gametype IOURTS new extend Q3S
-    name = ioUrbanTerror
+    name = Urban Terror
     template var = IOURT
     game rule = gamename
 end
 
 gametype IOURTM new extend Q3M
-    name = ioUrbanTerror Master
+    name = Urban Terror Master
     template var = IOURTMASTER
-    default port = 27950
+    default port = 27900
     master packet = \377\377\377\377getservers %s %s
     master protocol = 68
     master query = empty full
     master for gametype = IOURTS
+end
+
+# id Tech 3 fork (ioquake3 engine, Quake 3 derivative)
+gametype REACTIONS new extend Q3S
+    name = Reaction
+    template var = REACTION
+    game rule = gamename
+end
+
+gametype REACTIONM new extend Q3M
+    name = Reaction Master
+    template var = REACTIONMASTER
+    default port = 27950
+    master packet = \377\377\377\377getservers %s %s
+    master protocol = 68
+    master query = empty full
+    master for gametype = REACTIONS
+end
+
+# id Tech 3 fork (ioquake3 engine, Quake 3 derivative)
+gametype SMOKINGUNSS new extend Q3S
+    name = Smokin' Guns
+    template var = SMOKINGUNS
+    game rule = gamename
+end
+
+gametype SMOKINGUNSM new extend Q3M
+    name = Smokin' Guns Master
+    template var = SMOKINGUNSMASTER
+    default port = 27960
+    master packet = \377\377\377\377getservers %s %s
+    master protocol = 68
+    master query = empty full
+    master for gametype = SMOKINGUNSS
+end
+
+# id Tech 3 fork (ioquake3 engine, Quake 3 derivative)
+gametype ZEQ2LITES new extend Q3S
+    name = ZEQ2 Lite
+    template var = ZEQ2LITE
+    game rule = gamename
+end
+
+gametype ZEQ2LITEM new extend Q3M
+    name = ZEQ2 Lite Master
+    template var = ZEQ2LITEMASTER
+    default port = 27960
+    master packet = \377\377\377\377getservers %s %s
+    master protocol = 75
+    master query = empty full
+    master for gametype = ZEQ2LITES
+end
+
+# id Tech 3 fork (ioquake3 engine, Quake 3 derivative)
+gametype TURTLEARENAS new extend Q3S
+    name = Turtle Arena
+    template var = TURTLEARENA
+    default port = 27960
+    game rule = gamename
+end
+
+gametype TURTLEARENAM new extend Q3M
+    name = Turtle Arena Master
+    template var = TURTLEARENAMASTER
+    default port = 27950
+    master packet = \377\377\377\377getservers TurtleArena %s %s
+    master protocol = 9
+    master query = empty full
+    master for gametype = TURTLEARENAS
+end
+
+# id Tech 2 fork (CRX engine, Quake 2 derivative)
+gametype ALIENARENAS new extend Q2S
+    name = Alien Arena
+    template var = ALIENARENA
+    game rule = gamename
+end
+
+gametype ALIENARENAM new extend Q2M
+    name = Alien Arena Master
+    template var = ALIENARENAMASTER
+    default port = 27900
+    master protocol = 34
+    master query = empty full
+    master for gametype = ALIENARENAS
 end


### PR DESCRIPTION
Hi, this is the modifications I made to `qstat.cfg` to add these games to [XQF](https://github.com/XQF/xqf):
- Et:Legacy (Wolf:ET fork)
- TremulousGPP (Tremulous fork, id Tech 3 derivative)
- TremFusion (Tremulous fork, id Tech 3 derivative)
- Unvanquished (Tremulous fork, id Tech 3 and XreaL derivative)
- Xonotic (Nexuiz fork, Id Tech 1 derivative - Darkplace)
- Jedi Knight 2 Outcast - patch by VictorBE
- Q3Rally (Car Racing Id Tech 3 mod become standalone)
- World of Padman (Colorful Id Tech 3 mod become standalone)
- Reaction (Action Id Tech 3 mod become standalone)
- Smokin' Guns (Western Id Tech 3 mod become standalone)
- ZEQ2 Lite (Dragon Ball Id Tech 3 mod become standalone)
- Turtle Arena (Ninja Turtles id Tech 3 derivative)
- Alien Arena (Extraterrestrial id Tech 2 derivative - CRX engine)

And there is some fixes for other games (default port for example).

Beware, there is one notable change, the tremulous support is now unified with other games, as `-tremulousm` and `-tremulouss` arguments and not `-tremulous` without the ending `s` for _server_.
