### PR TITLE
Fix Teeworlds server query, #3

### DIFF
--- a/qstat.h
+++ b/qstat.h
@@ -870,10 +870,6 @@ char ottd_serverdetails[] = {
 	0x02,		// packet type
 };
 
-/* Teeworlds */
-
-char tee_serverstatus[14] = { '\x20', '\0', '\0', '\0', '\0', '\0', '\xFF', '\xFF', '\xFF', '\xFF', 'g', 'i', 'e', 'f' };
-
 /* Cube2 */
 
 char cube2_serverstatus[3] = {'\x80', '\x10', '\x27'};
@@ -3072,18 +3068,18 @@ server_type builtin_types[] = {
 {
     /* Teeworlds */
     TEE_SERVER,						/* id */
-    "TEE",							/* type_prefix */
-    "tee",							/* type_string */
-    "-tee",							/* type_option */
-    "Teeworlds",		/* game_name */
+    "TEES",							/* type_prefix */
+    "tees",							/* type_string */
+    "-tees",						/* type_option */
+    "Teeworlds",					/* game_name */
     0,								/* master */
     35515,							/* default_port */
     0,								/* port_offset */
-    0,				/* flags */
-    "gametype",							/* game_rule */
-    "TEE",							/* template_var */
-    tee_serverstatus,						/* status_packet */
-    sizeof(tee_serverstatus),					/* status_len */
+    0,								/* flags */
+    "gametype",						/* game_rule */
+    "TEEWORLDS",					/* template_var */
+    NULL,							/* status_packet */
+    0,								/* status_len */
     NULL,							/* player_packet */
     0,								/* player_len */
     NULL,							/* rule_packet */
@@ -3092,16 +3088,16 @@ server_type builtin_types[] = {
     0,								/* master_len */
     NULL,							/* master_protocol */
     NULL,							/* master_query */
-    display_tee_player_info,			/* display_player_func */
+    display_tee_player_info,		/* display_player_func */
     display_server_rules,			/* display_rule_func */
-    raw_display_tee_player_info,		/* display_raw_player_func */
+    raw_display_tee_player_info,	/* display_raw_player_func */
     raw_display_server_rules,		/* display_raw_rule_func */
-    xml_display_tee_player_info,		/* display_xml_player_func */
+    xml_display_tee_player_info,	/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
-    send_tee_request_packet,			/* status_query_func */
+    send_teeserver_request_packet,	/* status_query_func */
     NULL,							/* rule_query_func */
     NULL,							/* player_query_func */
-    deal_with_tee_packet,			/* packet_func */
+    deal_with_teeserver_packet,		/* packet_func */
 },
 {
     /* TEAMSPEAK 3 PROTOCOL */

--- a/tee.c
+++ b/tee.c
@@ -3,10 +3,11 @@
  * by Steve Jankowski
  *
  * Teeworlds protocol
- * Copyright 2008 ? Emiliano Leporati
+ * Thanks to Emiliano Leporati for the first Teeworlds patch (2008)
+ * Thanks to Thomas Debesse for the rewrite <dev@illwieckz.net> (2014)
+ * Thanks to Steven Hartland for some parts and help <steven.hartland@multiplay.co.uk>
  *
  * Licensed under the Artistic License, see LICENSE.txt for license terms
- *
  */
 
 #include <string.h>
@@ -17,76 +18,187 @@
 #include "qstat.h"
 #include "packet_manip.h"
 
-char tee_serverinfo[8] = { '\xFF', '\xFF', '\xFF', '\xFF', 'i', 'n', 'f', 'o' };
+/* See "scripts/tw_api.py" from Teeworlds project */
 
-query_status_t send_tee_request_packet( struct qserver *server )
+/* query server */
+int len_teeserver_request_packet = 15;
+char teeserver_request_packet[15] = { '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', 'g', 'i', 'e', '\x00', '\x00'};
+
+/* server response */
+int len_teeserver_info_headerprefix = 13;
+char teeserver_info_headerprefix[13] = { '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', 'i', 'n', 'f' };
+
+/* 
+ * To request, we will try 3 request packet, only one character and the size change, so no need to declare 3 strings
+ *
+ * char teeserver_request_packet[14] = { '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', 'g', 'i', 'e', 'f' };
+ * char teeserver_request_packe2[15] = { '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', 'g', 'i', 'e', '2', '\x00' };
+ * char teeserver_request_packe3[15] = { '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', 'g', 'i', 'e', '3', '\x00' };
+ *
+ * To analyze response, we will compare the same string without the last character, then the last character, so no need to declare 3 strings
+ * 
+ * char teeserver_info_header[14] = { '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', 'i', 'n', 'f', 'o' };
+ * char teeserver_inf2_header[14] = { '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', 'i', 'n', 'f', '2' };
+ * char teeserver_inf3_header[14] = { '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', 'i', 'n', 'f', '3' };
+ */
+
+/* 
+ * For information, Tee packet samples per header, explained
+ *
+ * Header "info": \xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', 'i', 'n', 'f', 'o'
+ * Answer sample: '\xff\xff\xff\xff\xff\xff\xff\xff\xff\xffinfo0.5.1\x00.:{TeeKnight|Catch16}:. Catch16 hosted by TeeKnight.de\x00lightcatch\x00Catch16\x000\x00-1\x000\x0016\x00'
+ * Answer format: (*char)header,(*char)version,(*char)name,(*char)map,(*char)gametype,(int)flags,(int)progression,(int)num_players,(int)max_players,*players[]
+ *
+ * Header "inf2": \xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', 'i', 'n', 'f', '2'
+ * Answer sample: '\xff\xff\xff\xff\xff\xff\xff\xff\xff\xffinf20\x000.5.1\x00.:{TeeKnight|Catch16}:. Catch16 hosted by TeeKnight.de\x00lightcatch\x00Catch16\x000\x00-1\x000\x0016\x00'
+ * Answer format: (*char)header,(*char)token,(*char)version),(*char)name,(*char)map,(*char)gametype,(int)flags,(int)progression,(int)num_players,(int)max_players,*players[]
+ *
+ * Header "inf3": \xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', '\xFF', 'i', 'n', 'f', '3'
+ * Answer sample: '\xff\xff\xff\xff\xff\xff\xff\xff\xff\xffinf30\x000.6.1\x00[Bigstream.ru] CTF5 only\x00ctf5\x00CTF\x000\x000\x0016\x000\x0016\x00'
+ * Answer format: (*char)header,(*char)token,(*char)version),(*char)name,(*char)map,(*char)gametype,(int)flags,(int)num_players,(int)max_players,(int)num_clients,(int)max_clients,*players[]
+ */
+
+query_status_t send_teeserver_request_packet(struct qserver *server)
 {
-	return send_packet( server, server->type->status_packet, server->type->status_len );
+	query_status_t ret;
+
+	/* 
+	 * Try first then second then third...
+	 * In fact the master server said which server use which protocol, but how qstat can transmit this information?
+	 */
+
+	/* Send v1 packet */
+	teeserver_request_packet[13] = 'f';
+	ret = send_packet(server, teeserver_request_packet, 13);
+	if (ret != INPROGRESS) {
+	    return (ret);
+	}
+
+	/* Send v2 packet */
+	teeserver_request_packet[13] = '2';
+	ret = send_packet(server, teeserver_request_packet, len_teeserver_request_packet);
+	if (ret != INPROGRESS) {
+	    return (ret);
+	}
+
+	/* Send v2 packet */
+	teeserver_request_packet[13] = '3';
+	return (send_packet(server, teeserver_request_packet, len_teeserver_request_packet));
 }
 
-query_status_t deal_with_tee_packet( struct qserver *server, char *rawpkt, int pktlen )
+query_status_t deal_with_teeserver_packet(struct qserver *server, char *rawpkt, int rawpktlen)
 {
-	// skip unimplemented ack, crc, etc
-	char *pkt = rawpkt + 6;
-	char *tok = NULL, *version = NULL;
-	int i;
+	int i, skip;
+	char last_char;
+	char *current = NULL, *end = NULL, *version = NULL, *tok = NULL;
 	struct player* player;
 
 	server->ping_total += time_delta(&packet_recv_time, &server->packet_time1);
 
-	if (0 == memcmp( pkt, tee_serverinfo, 8)) 
-	{
-		pkt += 8;
-		// version
-		version = strdup(pkt); pkt += strlen(pkt) + 1;
-		// server name
-		server->server_name = strdup(pkt); pkt += strlen(pkt) + 1;
-		// map name
-		server->map_name = strdup(pkt); pkt += strlen(pkt) + 1;
-		// game type
-		switch(atoi(pkt)) {
-		case 0:
-			add_rule( server, server->type->game_rule, "dm", NO_FLAGS);
-			break;
-		case 1:
-			add_rule( server, server->type->game_rule, "tdm", NO_FLAGS);
-			break;
-		case 2:
-			add_rule( server, server->type->game_rule, "ctf", NO_FLAGS);
-			break;
-		default:
-			add_rule( server, server->type->game_rule, "unknown", NO_FLAGS);
-			break;
-		}
-		pkt += strlen(pkt) + 1; 
-		pkt += strlen(pkt) + 1;
-		pkt += strlen(pkt) + 1;
-		// num players
-		server->num_players = atoi(pkt); pkt += strlen(pkt) + 1;
-		// max players
-		server->max_players = atoi(pkt); pkt += strlen(pkt) + 1;
-		// players
-		for(i = 0; i < server->num_players; i++)
-		{
-			player = add_player( server, i );
-			player->name = strdup(pkt); pkt += strlen(pkt) + 1;
-			player->score = atoi(pkt); pkt += strlen(pkt) + 1;
-		}
-		// version reprise
-		server->protocol_version = 0;
-
-		if (NULL == (tok = strtok(version, "."))) return -1;
-		server->protocol_version |= (atoi(tok) & 0x000F) << 12;
-		if (NULL == (tok = strtok(NULL, "."))) return -1;
-		server->protocol_version |= (atoi(tok) & 0x000F) << 8;
-		if (NULL == (tok = strtok(NULL, "."))) return -1;
-		server->protocol_version |= (atoi(tok) & 0x00FF);
-
-		free(version);
-
-		return DONE_FORCE;
+	/* packet too short */
+	if (len_teeserver_info_headerprefix > rawpktlen) {
+		return (PKT_ERROR);
 	}
 
-	// unknown packet type
-	return PKT_ERROR;
+	/* not null-terminated packet */
+	if (strnlen(rawpkt, rawpktlen) == rawpktlen && rawpkt[rawpktlen] != 0) {
+		return (PKT_ERROR);
+	}
+
+	/* get the last character */
+	last_char = rawpkt[len_teeserver_info_headerprefix];
+
+	/* compare the response without the last character, and verify if the last character is 'o', '2' or '3' */
+	if (memcmp(rawpkt + skip, teeserver_info_headerprefix, len_teeserver_info_headerprefix) != 0 || (last_char != 'o' && last_char != '2' && last_char != '3')) {
+		return (PKT_ERROR);
+	}
+
+	current = rawpkt;
+	end = rawpkt + rawpktlen;
+
+	/* header, skip */
+	current += len_teeserver_info_headerprefix + sizeof(last_char); 
+
+	/* if inf2 or inf3 */
+	if (last_char == '2' || last_char == '3') {
+		/* token, skip */
+		current += strnlen(current, end - current) + 1; 
+	}
+
+	/* version */
+	version = current;
+	current += strnlen(current, end - current) + 1;
+
+	/* server name */
+	server->server_name = strdup(current);
+	current += strnlen(current, end - current) + 1;
+
+	/* map name */
+	server->map_name = strdup(current);
+	current += strnlen(current, end - current) + 1;
+
+	/* game type */
+	add_rule(server, server->type->game_rule, current, NO_FLAGS);
+	current += strnlen(current, end - current) + 1;
+
+	/* flags, skip */
+	current += strnlen(current, end - current) + 1; 
+
+	/* if info or inf2 */
+	if (last_char == 'o' || last_char == '2') {
+		// progression, skip
+		current += strnlen(current, end - current) + 1; 
+	}
+	
+	/* num players */
+	server->num_players = atoi(current);
+	current += strnlen(current, end - current) + 1;
+
+	/* max players */
+	server->max_players = atoi(current);
+	current += strnlen(current, end - current) + 1;
+
+	/* if inf3 */
+	if (last_char == '3') {
+		/* Is there a difference between a teeworld spectator and what qstat calls a "client"?  */
+
+		/* num clients, skip */
+		current += strnlen(current, end - current) + 1;
+
+		/* max clients, skip */
+		current += strnlen(current, end - current) + 1;
+	}
+
+	/* players */
+	for (i = 0; i < server->num_players; i++) {
+		player = add_player(server, i);
+		player->name = strdup(current);
+		current += strnlen(current, end - current) + 1;
+
+		player->score = atoi(current);
+		current += strnlen(current, end - current) + 1;
+	}
+
+	/* version reprise */
+	server->protocol_version = 0;
+
+	tok = strtok(version, ".");
+	if (tok == NULL) {
+		return (PKT_ERROR);
+	}
+	server->protocol_version |= (atoi(tok) & 0x000F) << 12;
+
+	tok = strtok(NULL, ".");
+	if (tok == NULL) {
+		return (PKT_ERROR);
+	}
+	server->protocol_version |= (atoi(tok) & 0x000F) << 8;
+
+	tok = strtok(NULL, ".");
+	if (tok == NULL) {
+		return (PKT_ERROR);
+	}
+	server->protocol_version |= (atoi(tok) & 0x00FF);
+
+	return (DONE_FORCE);
 }

--- a/tee.h
+++ b/tee.h
@@ -13,8 +13,8 @@
 #include "qserver.h"
 
 // Packet processing methods
-query_status_t deal_with_tee_packet( struct qserver *server, char *pkt, int pktlen );
-query_status_t send_tee_request_packet( struct qserver *server );
+query_status_t send_teeserver_request_packet(struct qserver *server);
+query_status_t deal_with_teeserver_packet(struct qserver *server, char *rawpkt, int pktlen);
 
 #endif
 


### PR DESCRIPTION
Hi, this fixes the Teeworlds server query, it tries with the 3 known `getinfo` packets.

I renamed the `-tee` argument to `-tees` since I will work next on the `-teem` Teeworlds master query.

Since Teeworlds support was broken since many years, there is probably nobody that uses the `-tee` arg today.
