### PR TITLE
fix etlegacy/wolfet, warsow and q3rally server query

### DIFF
--- a/qstat.cfg
+++ b/qstat.cfg
@@ -160,7 +160,7 @@ gametype WOETM new extend Q3M
     template var = WOETSMASTER
     master protocol = 84
     master for gametype = WOETS
-    master query =
+    master query = empty full
 end
 
 # id Tech 3 (Enemy Territory: Legacy fork)
@@ -174,7 +174,7 @@ gametype ETLM new extend Q3M
     template var = ETLMASTER
     master protocol = 84
     master for gametype = ETLS
-    master query =
+    master query = empty full
 end
 
 # NetPanzer > 0.1.6

--- a/qstat.cfg
+++ b/qstat.cfg
@@ -245,7 +245,7 @@ gametype XONOTICM new extend Q3M
 end
 
 # id Tech 2 fork (Qfusion engine, Quake 1 derivative)
-gametype WARSOWS new extend Q2S
+gametype WARSOWS new extend Q3S
     name = Warsow
     template var = WARSOW
     default port = 44400
@@ -387,7 +387,7 @@ gametype Q3RALLYM new extend Q3M
     name = Q3 Rally Master
     template var = Q3RALLYMASTER
     default port = 27950
-    master packet = \377\377\377\377getservers %s %s
+    master packet = \377\377\377\377getservers Q3Rally %s %s
     master protocol = 71
     master query = empty full
     master for gametype = Q3RALLYS


### PR DESCRIPTION
Hi, three fixes from the [XQF](https://github.com/XQF/xqf/) project:

* fix warsow qstat.cfg breaking getting servers for any game. The issue is apparently that Q2S doesn't have status2 packet. So use Q3S, which some other id tech 2 games already use (such as Nexuiz).
https://github.com/XQF/xqf/commit/ee2a392f150251b33a1ebda5cf2874290feaa181 by @zturtleman

* use dpmaster gamename when requesting servers for q3rally
https://github.com/XQF/xqf/commit/ce32b3608a912bb78d1b6faafc62504effdf62e8 by @zturtleman

* allow xqf/qstat to query empties and full wolfet/etlegacy servers
https://github.com/XQF/xqf/commit/f63633570f8ca17763ff430e851e592e1794289b by @illwieckz