### PR TITLE
Add json support, fix #10, ref XQF/xqf#12 

### DIFF
--- a/qstat.c
+++ b/qstat.c
@@ -2613,6 +2613,7 @@ void json_protocols()
 void json_version()
 {
 	printf("{\n\t\"version\": \"%s\"\n}\n", VERSION);
+	exit(0);
 }
 
 void json_display_server(struct qserver *server)

--- a/qstat.c
+++ b/qstat.c
@@ -205,7 +205,6 @@ int output_bom = 0;
 int xml_display = 0;
 int xml_encoding = ENCODING_LATIN_1;
 int json_display = 0;
-int json_encoding = ENCODING_LATIN_1;
 int json_printed = 0;
 
 #define SUPPORTED_SERVER_SORT	"pgihn"
@@ -2583,6 +2582,7 @@ void xml_display_tee_player_info(struct qserver *server)
  * JSON output
  * Contributed by Steve Teuber <steve@exprojects.org>
  */
+
 void json_protocols()
 {
 	int i;
@@ -2591,7 +2591,7 @@ void json_protocols()
 
 	sorted_types = (server_type **)malloc(sizeof(server_type*) * n_server_types);
 	type = &types[0];
-	for (i = 0; type->id != Q_UNKNOWN_TYPE; type++, i++)
+	for (i = 0; type->id != Q_UNKNOWN_TYPE && i < n_server_types; type++, i++)
 	{
 		sorted_types[i] = type;
 	}
@@ -2625,12 +2625,12 @@ void json_display_server(struct qserver *server)
 	{
 		if (!up_servers_only)
 		{
-			fprintf(OF, "%s\n", (json_printed) ? ",\n\t{" : "\t{");
-			fprintf(OF, "\t\t\"protocol\": \"%s\",\n", json_escape(prefix));
-			fprintf(OF, "\t\t\"address\": \"%s\",\n", json_escape(server->arg));
-			fprintf(OF, "\t\t\"status\": \"%s\",\n", json_escape("offline"));
-			fprintf(OF, "\t\t\"hostname\": \"%s\"\n", json_escape((hostname_lookup) ? server->host_name: server->arg));
-			fprintf(OF, "\t}");
+			xform_printf(OF, (json_printed) ? ",\n\t{\n" : "\t{\n");
+			xform_printf(OF, "\t\t\"protocol\": \"%s\",\n", json_escape(prefix));
+			xform_printf(OF, "\t\t\"address\": \"%s\",\n", json_escape(server->arg));
+			xform_printf(OF, "\t\t\"status\": \"%s\",\n", json_escape("offline"));
+			xform_printf(OF, "\t\t\"hostname\": \"%s\"\n", json_escape((hostname_lookup) ? server->host_name: server->arg));
+			xform_printf(OF, "\t}");
 			json_printed = 1;
 		}
 		return;
@@ -2639,22 +2639,22 @@ void json_display_server(struct qserver *server)
 	{
 		if (server->flags &FLAG_BROADCAST && server->n_servers)
 		{
-			fprintf(OF, "%s\n", (json_printed) ? ",\n\t{" : "\t{");
-			fprintf(OF, "\t\t\"protocol\": \"%s\",\n", json_escape(prefix));
-			fprintf(OF, "\t\t\"address\": \"%s\",\n", json_escape(server->arg));
-			fprintf(OF, "\t\t\"status\": \"%s\",\n", json_escape("timeout"));
-			fprintf(OF, "\t\t\"servers\": %d\n", server->n_servers);
-			fprintf(OF, "\t}");
+			xform_printf(OF, (json_printed) ? ",\n\t{\n" : "\t{\n");
+			xform_printf(OF, "\t\t\"protocol\": \"%s\",\n", json_escape(prefix));
+			xform_printf(OF, "\t\t\"address\": \"%s\",\n", json_escape(server->arg));
+			xform_printf(OF, "\t\t\"status\": \"%s\",\n", json_escape("timeout"));
+			xform_printf(OF, "\t\t\"servers\": %d\n", server->n_servers);
+			xform_printf(OF, "\t}");
 			json_printed = 1;
 		}
 		else if (!up_servers_only)
 		{
-			fprintf(OF, "%s\n", (json_printed) ? ",\n\t{" : "\t{");
-			fprintf(OF, "\t\t\"protocol\": \"%s\",\n", json_escape(prefix));
-			fprintf(OF, "\t\t\"address\": \"%s\",\n", json_escape(server->arg));
-			fprintf(OF, "\t\t\"status\": \"%s\",\n", json_escape("timeout"));
-			fprintf(OF, "\t\t\"hostname\": \"%s\"\n", json_escape((hostname_lookup) ? server->host_name: server->arg));
-			fprintf(OF, "\t}");
+			xform_printf(OF, (json_printed) ? ",\n\t{\n" : "\t{\n");
+			xform_printf(OF, "\t\t\"protocol\": \"%s\",\n", json_escape(prefix));
+			xform_printf(OF, "\t\t\"address\": \"%s\",\n", json_escape(server->arg));
+			xform_printf(OF, "\t\t\"status\": \"%s\",\n", json_escape("timeout"));
+			xform_printf(OF, "\t\t\"hostname\": \"%s\"\n", json_escape((hostname_lookup) ? server->host_name: server->arg));
+			xform_printf(OF, "\t}");
 			json_printed = 1;
 		}
 		return ;
@@ -2662,76 +2662,76 @@ void json_display_server(struct qserver *server)
 
 	if (server->error != NULL)
 	{
-		fprintf(OF, "%s\n", (json_printed) ? ",\n\t{" : "\t{");
-		fprintf(OF, "\t\t\"protocol\": \"%s\",\n", json_escape(prefix));
-		fprintf(OF, "\t\t\"address\": \"%s\",\n", json_escape(server->arg));
-		fprintf(OF, "\t\t\"status\": \"%s\",\n", json_escape("error"));
-		fprintf(OF, "\t\t\"hostname\": \"%s\"\n", json_escape((hostname_lookup) ? server->host_name: server->arg));
-		fprintf(OF, "\t\t\"error\": \"%s\",\n", json_escape(server->error));
-		fprintf(OF, "\t}");
+		xform_printf(OF, (json_printed) ? ",\n\t{\n" : "\t{\n");
+		xform_printf(OF, "\t\t\"protocol\": \"%s\",\n", json_escape(prefix));
+		xform_printf(OF, "\t\t\"address\": \"%s\",\n", json_escape(server->arg));
+		xform_printf(OF, "\t\t\"status\": \"%s\",\n", json_escape("error"));
+		xform_printf(OF, "\t\t\"hostname\": \"%s\"\n", json_escape((hostname_lookup) ? server->host_name: server->arg));
+		xform_printf(OF, "\t\t\"error\": \"%s\",\n", json_escape(server->error));
+		xform_printf(OF, "\t}");
 		json_printed = 1;
 	}
 	else if (server->type->master)
 	{
-		fprintf(OF, "%s\n", (json_printed) ? ",\n\t{" : "\t{");
-		fprintf(OF, "\t\t\"protocol\": \"%s\",\n", json_escape(prefix));
-		fprintf(OF, "\t\t\"address\": \"%s\",\n", json_escape(server->arg));
-		fprintf(OF, "\t\t\"status\": \"%s\",\n", json_escape("online"));
-		fprintf(OF, "\t\t\"servers\": %d,\n", server->n_servers);
+		xform_printf(OF, (json_printed) ? ",\n\t{\n" : "\t{\n");
+		xform_printf(OF, "\t\t\"protocol\": \"%s\",\n", json_escape(prefix));
+		xform_printf(OF, "\t\t\"address\": \"%s\",\n", json_escape(server->arg));
+		xform_printf(OF, "\t\t\"status\": \"%s\",\n", json_escape("online"));
+		xform_printf(OF, "\t\t\"servers\": %d,\n", server->n_servers);
 		json_printed = 1;
 	}
 	else
 	{
-		fprintf(OF, "%s\n", (json_printed) ? ",\n\t{" : "\t{");
-		fprintf(OF, "\t\t\"protocol\": \"%s\",\n", json_escape(prefix));
-		fprintf(OF, "\t\t\"address\": \"%s\",\n", json_escape(server->arg));
-		fprintf(OF, "\t\t\"status\": \"%s\",\n", json_escape("online"));
-		fprintf(OF, "\t\t\"hostname\": \"%s\",\n", json_escape((hostname_lookup) ? server->host_name: server->arg));
-		fprintf(OF, "\t\t\"name\": \"%s\",\n", json_escape(xform_name(server->server_name, server)));
-		fprintf(OF, "\t\t\"gametype\": \"%s\",\n", json_escape(get_qw_game(server)));
-		fprintf(OF, "\t\t\"map\": \"%s\",\n", json_escape(xform_name(server->map_name, server)));
-		fprintf(OF, "\t\t\"numplayers\": %d,\n", server->num_players);
-		fprintf(OF, "\t\t\"maxplayers\": %d,\n", server->max_players);
-		fprintf(OF, "\t\t\"numspectators\": %d,\n", server->num_spectators);
-		fprintf(OF, "\t\t\"maxspectators\": %d", server->max_spectators);
+		xform_printf(OF, (json_printed) ? ",\n\t{\n" : "\t{\n");
+		xform_printf(OF, "\t\t\"protocol\": \"%s\",\n", json_escape(prefix));
+		xform_printf(OF, "\t\t\"address\": \"%s\",\n", json_escape(server->arg));
+		xform_printf(OF, "\t\t\"status\": \"%s\",\n", json_escape("online"));
+		xform_printf(OF, "\t\t\"hostname\": \"%s\",\n", json_escape((hostname_lookup) ? server->host_name: server->arg));
+		xform_printf(OF, "\t\t\"name\": \"%s\",\n", json_escape(xform_name(server->server_name, server)));
+		xform_printf(OF, "\t\t\"gametype\": \"%s\",\n", json_escape(get_qw_game(server)));
+		xform_printf(OF, "\t\t\"map\": \"%s\",\n", json_escape(xform_name(server->map_name, server)));
+		xform_printf(OF, "\t\t\"numplayers\": %d,\n", server->num_players);
+		xform_printf(OF, "\t\t\"maxplayers\": %d,\n", server->max_players);
+		xform_printf(OF, "\t\t\"numspectators\": %d,\n", server->num_spectators);
+		xform_printf(OF, "\t\t\"maxspectators\": %d", server->max_spectators);
 		json_printed = 1;
 
 		if (!(server->type->flags &TF_RAW_STYLE_TRIBES))
 		{
-			fprintf(OF, ",\n\t\t\"ping\": %d,\n", server->n_requests ? server->ping_total / server->n_requests: 999);
-			fprintf(OF, "\t\t\"retries\": %d", server->n_retries);
+			xform_printf(OF, ",\n\t\t\"ping\": %d,\n", server->n_requests ? server->ping_total / server->n_requests: 999);
+			xform_printf(OF, "\t\t\"retries\": %d", server->n_retries);
 		}
 
 		if (server->type->flags &TF_RAW_STYLE_QUAKE)
 		{
-			fprintf(OF, ",\n\t\t\"address\": %s,\n", json_escape(server->address));
-			fprintf(OF, "\t\t\"protocolversion\": %d", server->protocol_version);
+			xform_printf(OF, ",\n\t\t\"address\": %s,\n", json_escape(server->address));
+			xform_printf(OF, "\t\t\"protocolversion\": %d", server->protocol_version);
 		}
 	}
 
 	if (!server->type->master && server->error == NULL)
 	{
-		if (get_server_rules && NULL != server->type->display_json_rule_func )
+		if (get_server_rules && NULL != server->type->display_json_rule_func)
 		{
 			server->type->display_json_rule_func(server);
 		}
-		if (get_player_info && NULL != server->type->display_json_player_func )
+		if (get_player_info && NULL != server->type->display_json_player_func)
 		{
 			server->type->display_json_player_func(server);
 		}
 	}
 
-	fprintf(OF, "\n\t}");
+	xform_printf(OF, "\n\t}");
 }
 
 void json_header()
 {
-	fprintf(OF, "[\n");
+	xform_printf(OF, "[\n");
 }
 
 void json_footer()
 {
-	fprintf(OF, "\n]\n");
+	xform_printf(OF, "\n]\n");
 }
 
 void json_display_server_rules(struct qserver *server)
@@ -2740,14 +2740,17 @@ void json_display_server_rules(struct qserver *server)
 	int printed = 0;
 	rule = server->rules;
 
-	fprintf(OF, ",\n\t\t\"rules\": {\n");
+	xform_printf(OF, ",\n\t\t\"rules\": {\n");
 	for (; rule != NULL; rule = rule->next)
 	{
-		if (printed) fprintf(OF, ",\n");
-		fprintf(OF, "\t\t\t\"%s\": \"%s\"", json_escape(rule->name), json_escape(rule->value));
+		if (printed)
+		{
+			xform_printf(OF, ",\n");
+		}
+		xform_printf(OF, "\t\t\t\"%s\": \"%s\"", json_escape(rule->name), json_escape(rule->value));
 		printed = 1;
 	}
-	fprintf(OF, "\n\t\t}");
+	xform_printf(OF, "\n\t\t}");
 }
 
 void json_display_q_player_info(struct qserver *server)
@@ -2755,23 +2758,26 @@ void json_display_q_player_info(struct qserver *server)
 	struct player *player;
 	int printed = 0;
 
-	fprintf(OF, ",\n\t\t\"players\": [\n");
+	xform_printf(OF, ",\n\t\t\"players\": [\n");
 
 	player = server->players;
 	for (; player != NULL; player = player->next)
 	{
-		if (printed) fprintf(OF, ",\n");
-		fprintf(OF, "\t\t\t{\n");
-		fprintf(OF, "\t\t\t\"number\": %d,\n", player->number);
-		fprintf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
-		fprintf(OF, "\t\t\t\t\"address\": \"%s\",\n", json_escape(player->address));
-		fprintf(OF, "\t\t\t\t\"score\": %d,\n", player->frags);
-		fprintf(OF, "\t\t\t\t\"time\": \"%s\"\n", json_escape(play_time(player->connect_time, 2)));
-		fprintf(OF, "\t\t\t}");
+		if (printed)
+		{
+			xform_printf(OF, ",\n");
+		}
+		xform_printf(OF, "\t\t\t{\n");
+		xform_printf(OF, "\t\t\t\"number\": %d,\n", player->number);
+		xform_printf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
+		xform_printf(OF, "\t\t\t\t\"address\": \"%s\",\n", json_escape(player->address));
+		xform_printf(OF, "\t\t\t\t\"score\": %d,\n", player->frags);
+		xform_printf(OF, "\t\t\t\t\"time\": \"%s\"\n", json_escape(play_time(player->connect_time, 2)));
+		xform_printf(OF, "\t\t\t}");
 		printed = 1;
 	}
 
-	fprintf(OF, "\n\t\t]");
+	xform_printf(OF, "\n\t\t]");
 }
 
 void json_display_qw_player_info(struct qserver *server)
@@ -2779,25 +2785,28 @@ void json_display_qw_player_info(struct qserver *server)
 	struct player *player;
 	int printed = 0;
 
-	fprintf(OF, ",\n\t\t\"players\": [\n");
+	xform_printf(OF, ",\n\t\t\"players\": [\n");
 
 	player = server->players;
 	for (; player != NULL; player = player->next)
 	{
-		if (printed) fprintf(OF, ",\n");
-		fprintf(OF, "\t\t\t{\n");
-		fprintf(OF, "\t\t\t\t\"number\": %d,\n", player->number);
-		fprintf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
-		fprintf(OF, "\t\t\t\t\"score\": %d,\n", player->frags);
-		fprintf(OF, "\t\t\t\t\"time\": \"%s\",\n", json_escape(play_time(player->connect_time, 2)));
-		fprintf(OF, "\t\t\t\t\"ping\": %d,\n", player->ping);
-		fprintf(OF, "\t\t\t\t\"skin\": \"%s\",\n", player->skin ? json_escape(player->skin): "");
-		fprintf(OF, "\t\t\t\t\"team\": \"%s\"\n", player->team_name ? json_escape(player->team_name): "");
-		fprintf(OF, "\t\t\t}");
+		if (printed)
+		{
+			xform_printf(OF, ",\n");
+		}
+		xform_printf(OF, "\t\t\t{\n");
+		xform_printf(OF, "\t\t\t\t\"number\": %d,\n", player->number);
+		xform_printf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
+		xform_printf(OF, "\t\t\t\t\"score\": %d,\n", player->frags);
+		xform_printf(OF, "\t\t\t\t\"time\": \"%s\",\n", json_escape(play_time(player->connect_time, 2)));
+		xform_printf(OF, "\t\t\t\t\"ping\": %d,\n", player->ping);
+		xform_printf(OF, "\t\t\t\t\"skin\": \"%s\",\n", player->skin ? json_escape(player->skin): "");
+		xform_printf(OF, "\t\t\t\t\"team\": \"%s\"\n", player->team_name ? json_escape(player->team_name): "");
+		xform_printf(OF, "\t\t\t}");
 		printed = 1;
 	}
 
-	fprintf(OF, "\n\t\t]");
+	xform_printf(OF, "\n\t\t]");
 }
 
 void json_display_q2_player_info(struct qserver *server)
@@ -2805,25 +2814,28 @@ void json_display_q2_player_info(struct qserver *server)
 	struct player *player;
 	int printed = 0;
 
-	fprintf(OF, ",\n\t\t\"players\": [\n");
+	xform_printf(OF, ",\n\t\t\"players\": [\n");
 
 	player = server->players;
 	for (; player != NULL; player = player->next)
 	{
-		if (printed) fprintf(OF, ",\n");
-		fprintf(OF, "\t\t\t{\n");
-		fprintf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
-		fprintf(OF, "\t\t\t\t\"score\": %d,\n", player->frags);
+		if (printed)
+		{
+			xform_printf(OF, ",\n");
+		}
+		xform_printf(OF, "\t\t\t{\n");
+		xform_printf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
+		xform_printf(OF, "\t\t\t\t\"score\": %d,\n", player->frags);
 		if (server->flags &FLAG_PLAYER_TEAMS)
 		{
-			fprintf(OF, "\t\t\t\t\"team\": %d,\n", player->team);
+			xform_printf(OF, "\t\t\t\t\"team\": %d,\n", player->team);
 		}
-		fprintf(OF, "\t\t\t\t\"ping\": %d\n", player->ping);
-		fprintf(OF, "\t\t\t}");
+		xform_printf(OF, "\t\t\t\t\"ping\": %d\n", player->ping);
+		xform_printf(OF, "\t\t\t}");
 		printed = 1;
 	}
 
-	fprintf(OF, "\n\t\t]");
+	xform_printf(OF, "\n\t\t]");
 }
 
 void json_display_player_info_info(struct player *player)
@@ -2836,7 +2848,7 @@ void json_display_player_info_info(struct player *player)
 		{
 			char *name = json_escape(info->name);
 			char *value = json_escape(info->value);
-			fprintf(OF, "\t\t\t\t\"%s\": \"%s\",\n", name, value);
+			xform_printf(OF, "\t\t\t\t\"%s\": \"%s\",\n", name, value);
 		}
 	}
 }
@@ -2846,49 +2858,50 @@ void json_display_unreal_player_info(struct qserver *server)
 	struct player *player;
 	int printed = 0;
 
-	fprintf(OF, ",\n\t\t\"players\": [\n");
+	xform_printf(OF, ",\n\t\t\"players\": [\n");
 
 	player = server->players;
 	for (; player != NULL; player = player->next)
 	{
-		if (printed) fprintf(OF, ",\n");
-		fprintf(OF, "\t\t\t{\n");
-		fprintf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
-		fprintf(OF, "\t\t\t\t\"score\": %d,\n", player->frags);
-		if ( - 999 != player->deaths)
+		if (printed)
 		{
-			fprintf(OF, "\t\t\t\t\"deaths\": %d,\n", player->deaths);
+			xform_printf(OF, ",\n");
 		}
-		if (player->team_name)
+		xform_printf(OF, "\t\t\t{\n");
+		xform_printf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
+		xform_printf(OF, "\t\t\t\t\"score\": %d,\n", player->frags);
+		if (player->deaths != -999)
 		{
-			fprintf(OF, "\t\t\t\t\"team\": \"%s\",\n", json_escape(player->team_name));
+			xform_printf(OF, "\t\t\t\t\"deaths\": %d,\n", player->deaths);
 		}
-		else if ( - 1 != player->team)
+		if (player->team_name != NULL)
 		{
-			fprintf(OF, "\t\t\t\t\"team\": %d,\n", player->team);
+			xform_printf(OF, "\t\t\t\t\"team\": \"%s\",\n", json_escape(player->team_name));
+		}
+		else if (player->team != -1)
+		{
+			xform_printf(OF, "\t\t\t\t\"team\": %d,\n", player->team);
 		}
 
-		// Some games dont provide
-		// so only display if they do
-		if (player->skin)
+		if (player->skin != NULL)
 		{
-			fprintf(OF, "\t\t\t\t\"skin\": \"%s\",\n", player->skin ? json_escape(player->skin): "");
+			xform_printf(OF, "\t\t\t\t\"skin\": \"%s\",\n", player->skin ? json_escape(player->skin): "");
 		}
-		if (player->mesh)
+		if (player->mesh != NULL)
 		{
-			fprintf(OF, "\t\t\t\t\"mesh\": \"%s\",\n", player->mesh ? json_escape(player->mesh): "");
+			xform_printf(OF, "\t\t\t\t\"mesh\": \"%s\",\n", player->mesh ? json_escape(player->mesh): "");
 		}
-		if (player->face)
+		if (player->face != NULL)
 		{
-			fprintf(OF, "\t\t\t\t\"face\": \"%s\",\n", player->face ? json_escape(player->face): "");
+			xform_printf(OF, "\t\t\t\t\"face\": \"%s\",\n", player->face ? json_escape(player->face): "");
 		}
 		json_display_player_info_info(player);
-		fprintf(OF, "\t\t\t\t\"ping\": %d\n", player->ping);
-		fprintf(OF, "\t\t\t}");
+		xform_printf(OF, "\t\t\t\t\"ping\": %d\n", player->ping);
+		xform_printf(OF, "\t\t\t}");
 		printed = 1;
 	}
 
-	fprintf(OF, "\n\t\t]");
+	xform_printf(OF, "\n\t\t]");
 }
 
 void json_display_halflife_player_info(struct qserver *server)
@@ -2896,21 +2909,24 @@ void json_display_halflife_player_info(struct qserver *server)
 	struct player *player;
 	int printed = 0;
 
-	fprintf(OF, ",\n\t\t\"players\": [\n");
+	xform_printf(OF, ",\n\t\t\"players\": [\n");
 
 	player = server->players;
 	for (; player != NULL; player = player->next)
 	{
-		if (printed) fprintf(OF, ",\n");
-		fprintf(OF, "\t\t\t{\n");
-		fprintf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
-		fprintf(OF, "\t\t\t\t\"score\": %d,\n", player->frags);
-		fprintf(OF, "\t\t\t\t\"time\": \"%s\"\n", json_escape(play_time(player->connect_time, 2)));
-		fprintf(OF, "\t\t\t}");
+		if (printed)
+		{
+			xform_printf(OF, ",\n");
+		}
+		xform_printf(OF, "\t\t\t{\n");
+		xform_printf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
+		xform_printf(OF, "\t\t\t\t\"score\": %d,\n", player->frags);
+		xform_printf(OF, "\t\t\t\t\"time\": \"%s\"\n", json_escape(play_time(player->connect_time, 2)));
+		xform_printf(OF, "\t\t\t}");
 		printed = 1;
 	}
 
-	fprintf(OF, "\n\t\t]");
+	xform_printf(OF, "\n\t\t]");
 }
 
 void json_display_fl_player_info(struct qserver *server)
@@ -2918,23 +2934,26 @@ void json_display_fl_player_info(struct qserver *server)
 	struct player *player;
 	int printed = 0;
 
-	fprintf(OF, ",\n\t\t\"players\": [\n");
+	xform_printf(OF, ",\n\t\t\"players\": [\n");
 
 	player = server->players;
 	for (; player != NULL; player = player->next)
 	{
-		if (printed) fprintf(OF, ",\n");
-		fprintf(OF, "\t\t\t{\n");
-		fprintf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
-		fprintf(OF, "\t\t\t\t\"score\": %d,\n", player->frags);
-		fprintf(OF, "\t\t\t\t\"ping\": %d,\n", player->ping);
-		fprintf(OF, "\t\t\t\t\"team\": %d,\n", player->team);
-		fprintf(OF, "\t\t\t\t\"time\": \"%s\"\n", json_escape(play_time(player->connect_time, 2)));
-		fprintf(OF, "\t\t\t}");
+		if (printed)
+		{
+			xform_printf(OF, ",\n");
+		}
+		xform_printf(OF, "\t\t\t{\n");
+		xform_printf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
+		xform_printf(OF, "\t\t\t\t\"score\": %d,\n", player->frags);
+		xform_printf(OF, "\t\t\t\t\"ping\": %d,\n", player->ping);
+		xform_printf(OF, "\t\t\t\t\"team\": %d,\n", player->team);
+		xform_printf(OF, "\t\t\t\t\"time\": \"%s\"\n", json_escape(play_time(player->connect_time, 2)));
+		xform_printf(OF, "\t\t\t}");
 		printed = 1;
 	}
 
-	fprintf(OF, "\n\t\t]");
+	xform_printf(OF, "\n\t\t]");
 }
 
 void json_display_tribes_player_info(struct qserver *server)
@@ -2942,23 +2961,26 @@ void json_display_tribes_player_info(struct qserver *server)
 	struct player *player;
 	int printed = 0;
 
-	fprintf(OF, ",\n\t\t\"players\": [\n");
+	xform_printf(OF, ",\n\t\t\"players\": [\n");
 
 	player = server->players;
 	for (; player != NULL; player = player->next)
 	{
-		if (printed) fprintf(OF, ",\n");
-		fprintf(OF, "\t\t\t{\n");
-		fprintf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
-		fprintf(OF, "\t\t\t\t\"score\": %d,\n", player->frags);
-		fprintf(OF, "\t\t\t\t\"team\": %d,\n", player->team);
-		fprintf(OF, "\t\t\t\t\"ping\": %d,\n", player->ping);
-		fprintf(OF, "\t\t\t\t\"packetloss\": %d\n", player->packet_loss);
-		fprintf(OF, "\t\t\t}");
+		if (printed)
+		{
+			xform_printf(OF, ",\n");
+		}
+		xform_printf(OF, "\t\t\t{\n");
+		xform_printf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
+		xform_printf(OF, "\t\t\t\t\"score\": %d,\n", player->frags);
+		xform_printf(OF, "\t\t\t\t\"team\": %d,\n", player->team);
+		xform_printf(OF, "\t\t\t\t\"ping\": %d,\n", player->ping);
+		xform_printf(OF, "\t\t\t\t\"packetloss\": %d\n", player->packet_loss);
+		xform_printf(OF, "\t\t\t}");
 		printed = 1;
 	}
 
-	fprintf(OF, "\n\t\t]");
+	xform_printf(OF, "\n\t\t]");
 }
 
 void json_display_tribes2_player_info(struct qserver *server)
@@ -2967,12 +2989,12 @@ void json_display_tribes2_player_info(struct qserver *server)
 	int printed = 0;
 	char *type;
 
-	fprintf(OF, ",\n\t\t\"players\": [\n");
+	xform_printf(OF, ",\n\t\t\"players\": [\n");
 
 	player = server->players;
 	for (; player != NULL; player = player->next)
 	{
-		if (player->team_name)
+		if (player->team_name != NULL)
 		{
 			switch (player->type_flag)
 			{
@@ -2987,19 +3009,22 @@ void json_display_tribes2_player_info(struct qserver *server)
 					break;
 			}
 
-			if (printed) fprintf(OF, ",\n");
-			fprintf(OF, "\t\t\t{\n");
-			fprintf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
-			fprintf(OF, "\t\t\t\t\"score\": %d,\n", player->frags);
-			fprintf(OF, "\t\t\t\t\"team\": \"%s\",\n", json_escape(player->team_name));
-			fprintf(OF, "\t\t\t\t\"type\": \"%s\",\n", json_escape(type));
-			fprintf(OF, "\t\t\t\t\"clan\": \"%s\"\n", player->tribe_tag ? json_escape(xform_name(player->tribe_tag, server)): "");
-			fprintf(OF, "\t\t\t}");
+			if (printed)
+		{
+			xform_printf(OF, ",\n");
+		}
+			xform_printf(OF, "\t\t\t{\n");
+			xform_printf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
+			xform_printf(OF, "\t\t\t\t\"score\": %d,\n", player->frags);
+			xform_printf(OF, "\t\t\t\t\"team\": \"%s\",\n", json_escape(player->team_name));
+			xform_printf(OF, "\t\t\t\t\"type\": \"%s\",\n", json_escape(type));
+			xform_printf(OF, "\t\t\t\t\"clan\": \"%s\"\n", player->tribe_tag ? json_escape(xform_name(player->tribe_tag, server)): "");
+			xform_printf(OF, "\t\t\t}");
 			printed = 1;
 		}
 	}
 
-	fprintf(OF, "\n\t\t]");
+	xform_printf(OF, "\n\t\t]");
 }
 
 void json_display_bfris_player_info(struct qserver *server)
@@ -3007,25 +3032,28 @@ void json_display_bfris_player_info(struct qserver *server)
 	struct player *player;
 	int printed = 0;
 
-	fprintf(OF, ",\n\t\t\"players\": [\n");
+	xform_printf(OF, ",\n\t\t\"players\": [\n");
 
 	player = server->players;
 	for (; player != NULL; player = player->next)
 	{
-		if (printed) fprintf(OF, ",\n");
-		fprintf(OF, "\t\t\t{\n");
-		fprintf(OF, "\t\t\t\t\"number\": %d,\n", player->number);
-		fprintf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
-		fprintf(OF, "\t\t\t\t\"score\": %d,\n", player->score);
-		fprintf(OF, "\t\t\t\t\"frags\": %d,\n", player->frags);
-		fprintf(OF, "\t\t\t\t\"team\": \"%s\",\n", json_escape(player->team_name));
-		fprintf(OF, "\t\t\t\t\"ping\": %d,\n", player->ping);
-		fprintf(OF, "\t\t\t\t\"ship\": %d\n", player->ship);
-		fprintf(OF, "\t\t\t}");
+		if (printed)
+		{
+			xform_printf(OF, ",\n");
+		}
+		xform_printf(OF, "\t\t\t{\n");
+		xform_printf(OF, "\t\t\t\t\"number\": %d,\n", player->number);
+		xform_printf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
+		xform_printf(OF, "\t\t\t\t\"score\": %d,\n", player->score);
+		xform_printf(OF, "\t\t\t\t\"frags\": %d,\n", player->frags);
+		xform_printf(OF, "\t\t\t\t\"team\": \"%s\",\n", json_escape(player->team_name));
+		xform_printf(OF, "\t\t\t\t\"ping\": %d,\n", player->ping);
+		xform_printf(OF, "\t\t\t\t\"ship\": %d\n", player->ship);
+		xform_printf(OF, "\t\t\t}");
 		printed = 1;
 	}
 
-	fprintf(OF, "\n\t\t]");
+	xform_printf(OF, "\n\t\t]");
 }
 
 void json_display_descent3_player_info(struct qserver *server)
@@ -3033,23 +3061,26 @@ void json_display_descent3_player_info(struct qserver *server)
 	struct player *player;
 	int printed = 0;
 
-	fprintf(OF, ",\n\t\t\"players\": [\n");
+	xform_printf(OF, ",\n\t\t\"players\": [\n");
 
 	player = server->players;
 	for (; player != NULL; player = player->next)
 	{
-		if (printed) fprintf(OF, ",\n");
-		fprintf(OF, "\t\t\t{\n");
-		fprintf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
-		fprintf(OF, "\t\t\t\t\"score\": %d,\n", player->frags);
-		fprintf(OF, "\t\t\t\t\"deaths\": %d,\n", player->deaths);
-		fprintf(OF, "\t\t\t\t\"ping\": %d,\n", player->ping);
-		fprintf(OF, "\t\t\t\t\"team\": %d\n", player->team);
-		fprintf(OF, "\t\t\t}");
+		if (printed)
+		{
+			xform_printf(OF, ",\n");
+		}
+		xform_printf(OF, "\t\t\t{\n");
+		xform_printf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
+		xform_printf(OF, "\t\t\t\t\"score\": %d,\n", player->frags);
+		xform_printf(OF, "\t\t\t\t\"deaths\": %d,\n", player->deaths);
+		xform_printf(OF, "\t\t\t\t\"ping\": %d,\n", player->ping);
+		xform_printf(OF, "\t\t\t\t\"team\": %d\n", player->team);
+		xform_printf(OF, "\t\t\t}");
 		printed = 1;
 	}
 
-	fprintf(OF, "\n\t\t]");
+	xform_printf(OF, "\n\t\t]");
 }
 
 void json_display_ravenshield_player_info(struct qserver *server)
@@ -3057,21 +3088,24 @@ void json_display_ravenshield_player_info(struct qserver *server)
 	struct player *player;
 	int printed = 0;
 
-	fprintf(OF, ",\n\t\t\"players\": [\n");
+	xform_printf(OF, ",\n\t\t\"players\": [\n");
 
 	player = server->players;
 	for (; player != NULL; player = player->next)
 	{
-		if (printed) fprintf(OF, ",\n");
-		fprintf(OF, "\t\t\t{\n");
-		fprintf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
-		fprintf(OF, "\t\t\t\t\"score\": %d,\n", player->frags);
-		fprintf(OF, "\t\t\t\t\"time\": \"%s\"\n", json_escape(play_time(player->connect_time, 2)));
-		fprintf(OF, "\t\t\t}");
+		if (printed)
+		{
+			xform_printf(OF, ",\n");
+		}
+		xform_printf(OF, "\t\t\t{\n");
+		xform_printf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
+		xform_printf(OF, "\t\t\t\t\"score\": %d,\n", player->frags);
+		xform_printf(OF, "\t\t\t\t\"time\": \"%s\"\n", json_escape(play_time(player->connect_time, 2)));
+		xform_printf(OF, "\t\t\t}");
 		printed = 1;
 	}
 
-	fprintf(OF, "\n\t\t]");
+	xform_printf(OF, "\n\t\t]");
 }
 
 
@@ -3080,21 +3114,24 @@ void json_display_ghostrecon_player_info(struct qserver *server)
 	struct player *player;
 	int printed = 0;
 
-	fprintf(OF, ",\n\t\t\"players\": [\n");
+	xform_printf(OF, ",\n\t\t\"players\": [\n");
 
 	player = server->players;
 	for (; player != NULL; player = player->next)
 	{
-		if (printed) fprintf(OF, ",\n");
-		fprintf(OF, "\t\t\t{\n");
-		fprintf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
-		fprintf(OF, "\t\t\t\t\"deaths\": %d,\n", player->deaths);
-		fprintf(OF, "\t\t\t\t\"team\": %d\n", player->team);
-		fprintf(OF, "\t\t\t}");
+		if (printed)
+		{
+			xform_printf(OF, ",\n");
+		}
+		xform_printf(OF, "\t\t\t{\n");
+		xform_printf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
+		xform_printf(OF, "\t\t\t\t\"deaths\": %d,\n", player->deaths);
+		xform_printf(OF, "\t\t\t\t\"team\": %d\n", player->team);
+		xform_printf(OF, "\t\t\t}");
 		printed = 1;
 	}
 
-	fprintf(OF, "\n\t\t]");
+	xform_printf(OF, "\n\t\t]");
 }
 
 void json_display_eye_player_info(struct qserver *server)
@@ -3102,37 +3139,40 @@ void json_display_eye_player_info(struct qserver *server)
 	struct player *player;
 	int printed = 0;
 
-	fprintf(OF, ",\n\t\t\"players\": [\n");
+	xform_printf(OF, ",\n\t\t\"players\": [\n");
 
 	player = server->players;
 	for (; player != NULL; player = player->next)
 	{
-		if (printed) fprintf(OF, ",\n");
-		fprintf(OF, "\t\t\t{\n");
-		fprintf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
-		fprintf(OF, "\t\t\t\t\"score\": %d,\n", player->score);
-		if (player->team_name)
+		if (printed)
 		{
-			fprintf(OF, "\t\t\t\t\"team\": \"%s\",\n", json_escape(player->team_name));
+			xform_printf(OF, ",\n");
+		}
+		xform_printf(OF, "\t\t\t{\n");
+		xform_printf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
+		xform_printf(OF, "\t\t\t\t\"score\": %d,\n", player->score);
+		if (player->team_name != NULL)
+		{
+			xform_printf(OF, "\t\t\t\t\"team\": \"%s\",\n", json_escape(player->team_name));
 		}
 		else
 		{
-			fprintf(OF, "\t\t\t\t\"team\": %d,\n", player->team);
+			xform_printf(OF, "\t\t\t\t\"team\": %d,\n", player->team);
 		}
-		if (player->skin)
+		if (player->skin != NULL)
 		{
-			fprintf(OF, "\t\t\t\t\"skin\": \"%s\",\n", json_escape(player->skin));
+			xform_printf(OF, "\t\t\t\t\"skin\": \"%s\",\n", json_escape(player->skin));
 		}
-		if (player->connect_time)
+		if (player->connect_time != 0)
 		{
-			fprintf(OF, "\t\t\t\t\"time\": \"%s\",\n", json_escape(play_time(player->connect_time, 1)));
+			xform_printf(OF, "\t\t\t\t\"time\": \"%s\",\n", json_escape(play_time(player->connect_time, 1)));
 		}
-		fprintf(OF, "\t\t\t\t\"ping\": %d\n", player->ping);
-		fprintf(OF, "\t\t\t}");
+		xform_printf(OF, "\t\t\t\t\"ping\": %d\n", player->ping);
+		xform_printf(OF, "\t\t\t}");
 		printed = 1;
 	}
 
-	fprintf(OF, "\n\t\t]");
+	xform_printf(OF, "\n\t\t]");
 }
 
 void json_display_doom3_player_info(struct qserver *server)
@@ -3140,47 +3180,50 @@ void json_display_doom3_player_info(struct qserver *server)
 	struct player *player;
 	int printed = 0;
 
-	fprintf(OF, ",\n\t\t\"players\": [\n");
+	xform_printf(OF, ",\n\t\t\"players\": [\n");
 
 	player = server->players;
 	for (; player != NULL; player = player->next)
 	{
-		if (printed) fprintf(OF, ",\n");
-		fprintf(OF, "\t\t\t{\n");
-		fprintf(OF, "\t\t\t\t\"number\": %d,\n", player->number);
-		fprintf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
-		fprintf(OF, "\t\t\t\t\"score\": %d,\n", player->score);
-		if (player->tribe_tag)
+		if (printed)
 		{
-			fprintf(OF, "\t\t\t\t\"clan\": \"%s\",\n", player->tribe_tag ? json_escape(xform_name(player->tribe_tag, server)): "");
+			xform_printf(OF, ",\n");
+		}
+		xform_printf(OF, "\t\t\t{\n");
+		xform_printf(OF, "\t\t\t\t\"number\": %d,\n", player->number);
+		xform_printf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
+		xform_printf(OF, "\t\t\t\t\"score\": %d,\n", player->score);
+		if (player->tribe_tag != NULL)
+		{
+			xform_printf(OF, "\t\t\t\t\"clan\": \"%s\",\n", player->tribe_tag ? json_escape(xform_name(player->tribe_tag, server)): "");
 		}
 		else
 		{
-			fprintf(OF, "\t\t\t\t\"team\": %d,\n", player->team);
+			xform_printf(OF, "\t\t\t\t\"team\": %d,\n", player->team);
 		}
-		if (player->skin)
+		if (player->skin != NULL)
 		{
-			fprintf(OF, "\t\t\t\t\"skin\": \"%s\",\n", json_escape(player->skin));
+			xform_printf(OF, "\t\t\t\t\"skin\": \"%s\",\n", json_escape(player->skin));
 		}
-		if (player->type_flag)
+		if (player->type_flag != 0)
 		{
-			fprintf(OF, "\t\t\t\t\"type\": \"%s\",\n", "bot");
+			xform_printf(OF, "\t\t\t\t\"type\": \"%s\",\n", "bot");
 		}
 		else
 		{
-			fprintf(OF, "\t\t\t\t\"type\": \"%s\",\n", "player");
+			xform_printf(OF, "\t\t\t\t\"type\": \"%s\",\n", "player");
 		}
-		if (player->connect_time)
+		if (player->connect_time != 0)
 		{
-			fprintf(OF, "\t\t\t\t\"time\": \"%s\",\n", json_escape(play_time(player->connect_time, 2)));
+			xform_printf(OF, "\t\t\t\t\"time\": \"%s\",\n", json_escape(play_time(player->connect_time, 2)));
 		}
 		json_display_player_info_info(player);
-		fprintf(OF, "\t\t\t\t\"ping\": %d\n", player->ping);
-		fprintf(OF, "\t\t\t}");
+		xform_printf(OF, "\t\t\t\t\"ping\": %d\n", player->ping);
+		xform_printf(OF, "\t\t\t}");
 		printed = 1;
 	}
 
-	fprintf(OF, "\n\t\t]");
+	xform_printf(OF, "\n\t\t]");
 }
 
 void json_display_player_info(struct qserver *server)
@@ -3188,52 +3231,55 @@ void json_display_player_info(struct qserver *server)
 	struct player *player;
 	int printed = 0;
 
-	fprintf(OF, ",\n\t\t\"players\": [\n");
+	xform_printf(OF, ",\n\t\t\"players\": [\n");
 
 	player = server->players;
 	for (; player != NULL; player = player->next)
 	{
-		if (printed) fprintf(OF, ",\n");
-		fprintf(OF, "\t\t\t{\n");
+		if (printed)
+		{
+			xform_printf(OF, ",\n");
+		}
+		xform_printf(OF, "\t\t\t{\n");
 		if (NA_INT != player->ping)
 		{
-			fprintf(OF, "\t\t\t\t\"ping\": %d,\n", player->ping);
+			xform_printf(OF, "\t\t\t\t\"ping\": %d,\n", player->ping);
 		}
 		if (NA_INT != player->score)
 		{
-			fprintf(OF, "\t\t\t\t\"score\": %d,\n", player->score);
+			xform_printf(OF, "\t\t\t\t\"score\": %d,\n", player->score);
 		}
 		if (NA_INT != player->deaths)
 		{
-			fprintf(OF, "\t\t\t\t\"deaths\": %d,\n", player->deaths);
+			xform_printf(OF, "\t\t\t\t\"deaths\": %d,\n", player->deaths);
 		}
 		if (NA_INT != player->frags)
 		{
-			fprintf(OF, "\t\t\t\t\"frags\": %d,\n", player->frags);
+			xform_printf(OF, "\t\t\t\t\"frags\": %d,\n", player->frags);
 		}
-		if (player->team_name)
+		if (player->team_name != NULL)
 		{
-			fprintf(OF, "\t\t\t\t\"team\": \"%s\",\n", json_escape(player->team_name));
+			xform_printf(OF, "\t\t\t\t\"team\": \"%s\",\n", json_escape(player->team_name));
 		}
 		else if (NA_INT != player->team)
 		{
-			fprintf(OF, "\t\t\t\t\"team\": %d,\n", player->team);
+			xform_printf(OF, "\t\t\t\t\"team\": %d,\n", player->team);
 		}
-		if (player->skin)
+		if (player->skin != NULL)
 		{
-			fprintf(OF, "\t\t\t\t\"skin\": \"%s\",\n", json_escape(player->skin));
+			xform_printf(OF, "\t\t\t\t\"skin\": \"%s\",\n", json_escape(player->skin));
 		}
-		if (player->connect_time)
+		if (player->connect_time != 0)
 		{
-			fprintf(OF, "\t\t\t\t\"time\": \"%s\",\n", json_escape(play_time(player->connect_time, 1)));
+			xform_printf(OF, "\t\t\t\t\"time\": \"%s\",\n", json_escape(play_time(player->connect_time, 1)));
 		}
 		json_display_player_info_info(player);
-		fprintf(OF, "\t\t\t\t\"name\": \"%s\"\n", json_escape(xform_name(player->name, server)));
-		fprintf(OF, "\t\t\t}");
+		xform_printf(OF, "\t\t\t\t\"name\": \"%s\"\n", json_escape(xform_name(player->name, server)));
+		xform_printf(OF, "\t\t\t}");
 		printed = 1;
 	}
 
-	fprintf(OF, "\n\t\t]");
+	xform_printf(OF, "\n\t\t]");
 }
 
 void json_display_armyops_player_info(struct qserver *server)
@@ -3254,25 +3300,28 @@ void json_display_ts2_player_info(struct qserver *server)
 	struct player *player;
 	int printed = 0;
 
-	fprintf(OF, ",\n\t\t\"players\": [\n");
+	xform_printf(OF, ",\n\t\t\"players\": [\n");
 
 	player = server->players;
 	for (; player != NULL; player = player->next)
 	{
-		if (printed) fprintf(OF, ",\n");
-		fprintf(OF, "\t\t\t{\n");
-		fprintf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
-		if (player->connect_time)
+		if (printed)
 		{
-			fprintf(OF, "\t\t\t\t\"time\": \"%s\",\n", json_escape(play_time(player->connect_time, 2)));
+			xform_printf(OF, ",\n");
+		}
+		xform_printf(OF, "\t\t\t{\n");
+		xform_printf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
+		if (player->connect_time != 0)
+		{
+			xform_printf(OF, "\t\t\t\t\"time\": \"%s\",\n", json_escape(play_time(player->connect_time, 2)));
 		}
 		json_display_player_info_info(player);
-		fprintf(OF, "\t\t\t\t\"ping\": %d\n", player->ping);
-		fprintf(OF, "\t\t\t}");
+		xform_printf(OF, "\t\t\t\t\"ping\": %d\n", player->ping);
+		xform_printf(OF, "\t\t\t}");
 		printed = 1;
 	}
 
-	fprintf(OF, "\n\t\t]");
+	xform_printf(OF, "\n\t\t]");
 }
 
 void json_display_ts3_player_info(struct qserver *server)
@@ -3280,24 +3329,27 @@ void json_display_ts3_player_info(struct qserver *server)
 	struct player *player;
 	int printed = 0;
 
-	fprintf(OF, ",\n\t\t\"players\": [\n");
+	xform_printf(OF, ",\n\t\t\"players\": [\n");
 
 	player = server->players;
 	for (; player != NULL; player = player->next)
 	{
-		if (printed) fprintf(OF, ",\n");
-		fprintf(OF, "\t\t\t{\n");
-		if (player->connect_time)
+		if (printed)
 		{
-			fprintf(OF, "\t\t\t\t\"time\": \"%s\",\n", json_escape(play_time(player->connect_time, 2)));
+			xform_printf(OF, ",\n");
+		}
+		xform_printf(OF, "\t\t\t{\n");
+		if (player->connect_time != 0)
+		{
+			xform_printf(OF, "\t\t\t\t\"time\": \"%s\",\n", json_escape(play_time(player->connect_time, 2)));
 		}
 		json_display_player_info_info(player);
-		fprintf(OF, "\t\t\t\t\"name\": \"%s\"\n", json_escape(xform_name(player->name, server)));
-		fprintf(OF, "\t\t\t}");
+		xform_printf(OF, "\t\t\t\t\"name\": \"%s\"\n", json_escape(xform_name(player->name, server)));
+		xform_printf(OF, "\t\t\t}");
 		printed = 1;
 	}
 
-	fprintf(OF, "\n\t\t]");
+	xform_printf(OF, "\n\t\t]");
 }
 
 void json_display_bfbc2_player_info(struct qserver *server)
@@ -3305,24 +3357,27 @@ void json_display_bfbc2_player_info(struct qserver *server)
 	struct player *player;
 	int printed = 0;
 
-	fprintf(OF, ",\n\t\t\"players\": [\n");
+	xform_printf(OF, ",\n\t\t\"players\": [\n");
 
 	player = server->players;
 	for (; player != NULL; player = player->next)
 	{
-		if (printed) fprintf(OF, ",\n");
-		fprintf(OF, "\t\t\t{\n");
-		if (player->connect_time)
+		if (printed)
 		{
-			fprintf(OF, "\t\t\t\t\"time\": \"%s\",\n", json_escape(play_time(player->connect_time, 2)));
+			xform_printf(OF, ",\n");
+		}
+		xform_printf(OF, "\t\t\t{\n");
+		if (player->connect_time != 0)
+		{
+			xform_printf(OF, "\t\t\t\t\"time\": \"%s\",\n", json_escape(play_time(player->connect_time, 2)));
 		}
 		json_display_player_info_info(player);
-		fprintf(OF, "\t\t\t\t\"name\": \"%s\"\n", json_escape(xform_name(player->name, server)));
-		fprintf(OF, "\t\t\t}");
+		xform_printf(OF, "\t\t\t\t\"name\": \"%s\"\n", json_escape(xform_name(player->name, server)));
+		xform_printf(OF, "\t\t\t}");
 		printed = 1;
 	}
 
-	fprintf(OF, "\n\t\t]");
+	xform_printf(OF, "\n\t\t]");
 }
 
 void json_display_wic_player_info(struct qserver *server)
@@ -3330,27 +3385,30 @@ void json_display_wic_player_info(struct qserver *server)
 	struct player *player;
 	int printed = 0;
 
-	fprintf(OF, ",\n\t\t\"players\": [\n");
+	xform_printf(OF, ",\n\t\t\"players\": [\n");
 
 	player = server->players;
 	for (; player != NULL; player = player->next)
 	{
-		if (printed) fprintf(OF, ",\n");
-		fprintf(OF, "\t\t\t{\n");
-		fprintf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
-		fprintf(OF, "\t\t\t\t\"score\": %d,\n", player->score);
-		fprintf(OF, "\t\t\t\t\"team\": \"%s\",\n", json_escape(player->team_name));
-		if ( player->tribe_tag )
+		if (printed)
 		{
-			fprintf(OF, "\t\t\t\t\"role\": \"%s\",\n", json_escape(player->tribe_tag));
+			xform_printf(OF, ",\n");
+		}
+		xform_printf(OF, "\t\t\t{\n");
+		xform_printf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
+		xform_printf(OF, "\t\t\t\t\"score\": %d,\n", player->score);
+		xform_printf(OF, "\t\t\t\t\"team\": \"%s\",\n", json_escape(player->team_name));
+		if (player->tribe_tag != NULL)
+		{
+			xform_printf(OF, "\t\t\t\t\"role\": \"%s\",\n", json_escape(player->tribe_tag));
 		}
 		json_display_player_info_info(player);
-		fprintf(OF, "\t\t\t\t\"bot\": %d\n", player->type_flag);
-		fprintf(OF, "\t\t\t}");
+		xform_printf(OF, "\t\t\t\t\"bot\": %d\n", player->type_flag);
+		xform_printf(OF, "\t\t\t}");
 		printed = 1;
 	}
 
-	fprintf(OF, "\n\t\t]");
+	xform_printf(OF, "\n\t\t]");
 }
 
 void json_display_ventrilo_player_info(struct qserver *server)
@@ -3358,22 +3416,25 @@ void json_display_ventrilo_player_info(struct qserver *server)
 	struct player *player;
 	int printed = 0;
 
-	fprintf(OF, ",\n\t\t\"players\": [\n");
+	xform_printf(OF, ",\n\t\t\"players\": [\n");
 
 	player = server->players;
 	for (; player != NULL; player = player->next)
 	{
-		if (printed) fprintf(OF, ",\n");
-		fprintf(OF, "\t\t\t{\n");
-		fprintf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
-		fprintf(OF, "\t\t\t\t\"ping\": %d,\n", player->ping);
-		fprintf(OF, "\t\t\t\t\"team\": \"%s\",\n", json_escape(player->team_name));
-		fprintf(OF, "\t\t\t\t\"time\": \"%s\"\n", json_escape(play_time(player->connect_time, 2)));
-		fprintf(OF, "\t\t\t}");
+		if (printed)
+		{
+			xform_printf(OF, ",\n");
+		}
+		xform_printf(OF, "\t\t\t{\n");
+		xform_printf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
+		xform_printf(OF, "\t\t\t\t\"ping\": %d,\n", player->ping);
+		xform_printf(OF, "\t\t\t\t\"team\": \"%s\",\n", json_escape(player->team_name));
+		xform_printf(OF, "\t\t\t\t\"time\": \"%s\"\n", json_escape(play_time(player->connect_time, 2)));
+		xform_printf(OF, "\t\t\t}");
 		printed = 1;
 	}
 
-	fprintf(OF, "\n\t\t]");
+	xform_printf(OF, "\n\t\t]");
 }
 
 void json_display_tm_player_info(struct qserver *server)
@@ -3381,25 +3442,28 @@ void json_display_tm_player_info(struct qserver *server)
 	struct player *player;
 	int printed = 0;
 
-	fprintf(OF, ",\n\t\t\"players\": [\n");
+	xform_printf(OF, ",\n\t\t\"players\": [\n");
 
 	player = server->players;
 	for (; player != NULL; player = player->next)
 	{
-		if (printed) fprintf(OF, ",\n");
-		fprintf(OF, "\t\t\t{\n");
-		fprintf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
-		if (player->connect_time)
+		if (printed)
 		{
-			fprintf(OF, "\t\t\t\t\"time\": \"%s\",\n", json_escape(play_time(player->connect_time, 2)));
+			xform_printf(OF, ",\n");
+		}
+		xform_printf(OF, "\t\t\t{\n");
+		xform_printf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
+		if (player->connect_time != 0)
+		{
+			xform_printf(OF, "\t\t\t\t\"time\": \"%s\",\n", json_escape(play_time(player->connect_time, 2)));
 		}
 		json_display_player_info_info(player);
-		fprintf(OF, "\t\t\t\t\"ping\": %d\n", player->ping);
-		fprintf(OF, "\t\t\t}");
+		xform_printf(OF, "\t\t\t\t\"ping\": %d\n", player->ping);
+		xform_printf(OF, "\t\t\t}");
 		printed = 1;
 	}
 
-	fprintf(OF, "\n\t\t]");
+	xform_printf(OF, "\n\t\t]");
 }
 
 
@@ -3408,21 +3472,24 @@ void json_display_savage_player_info(struct qserver *server)
 	struct player *player;
 	int printed = 0;
 
-	fprintf(OF, ",\n\t\t\"players\": [\n");
+	xform_printf(OF, ",\n\t\t\"players\": [\n");
 
 	player = server->players;
 	for (; player != NULL; player = player->next)
 	{
-		if (printed) fprintf(OF, ",\n");
-		fprintf(OF, "\t\t\t{\n");
-		fprintf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
-		fprintf(OF, "\t\t\t\t\"score\": %d,\n", player->frags);
-		fprintf(OF, "\t\t\t\t\"time\": \"%s\"\n", json_escape(play_time(player->connect_time, 2)));
-		fprintf(OF, "\t\t\t}");
+		if (printed)
+		{
+			xform_printf(OF, ",\n");
+		}
+		xform_printf(OF, "\t\t\t{\n");
+		xform_printf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
+		xform_printf(OF, "\t\t\t\t\"score\": %d,\n", player->frags);
+		xform_printf(OF, "\t\t\t\t\"time\": \"%s\"\n", json_escape(play_time(player->connect_time, 2)));
+		xform_printf(OF, "\t\t\t}");
 		printed = 1;
 	}
 
-	fprintf(OF, "\n\t\t]");
+	xform_printf(OF, "\n\t\t]");
 }
 
 void json_display_farcry_player_info(struct qserver *server)
@@ -3430,21 +3497,24 @@ void json_display_farcry_player_info(struct qserver *server)
 	struct player *player;
 	int printed = 0;
 
-	fprintf(OF, ",\n\t\t\"players\": [\n");
+	xform_printf(OF, ",\n\t\t\"players\": [\n");
 
 	player = server->players;
 	for (; player != NULL; player = player->next)
 	{
-		if (printed) fprintf(OF, ",\n");
-		fprintf(OF, "\t\t\t{\n");
-		fprintf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
-		fprintf(OF, "\t\t\t\t\"score\": %d,\n", player->frags);
-		fprintf(OF, "\t\t\t\t\"time\": \"%s\"\n", json_escape(play_time(player->connect_time, 2)));
-		fprintf(OF, "\t\t\t}");
+		if (printed)
+		{
+			xform_printf(OF, ",\n");
+		}
+		xform_printf(OF, "\t\t\t{\n");
+		xform_printf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
+		xform_printf(OF, "\t\t\t\t\"score\": %d,\n", player->frags);
+		xform_printf(OF, "\t\t\t\t\"time\": \"%s\"\n", json_escape(play_time(player->connect_time, 2)));
+		xform_printf(OF, "\t\t\t}");
 		printed = 1;
 	}
 
-	fprintf(OF, "\n\t\t]");
+	xform_printf(OF, "\n\t\t]");
 }
 
 void json_display_tee_player_info(struct qserver *server)
@@ -3452,21 +3522,54 @@ void json_display_tee_player_info(struct qserver *server)
 	struct player *player;
 	int printed = 0;
 
-	fprintf(OF, ",\n\t\t\"players\": [\n");
+	xform_printf(OF, ",\n\t\t\"players\": [\n");
 
 	player = server->players;
 	for (; player != NULL; player = player->next)
 	{
-		if (printed) fprintf(OF, ",\n");
-		fprintf(OF, "\t\t\t{\n");
-		fprintf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
-		fprintf(OF, "\t\t\t\t\"score\": %d\n", player->score);
-		fprintf(OF, "\t\t\t}");
+		if (printed)
+		{
+			xform_printf(OF, ",\n");
+		}
+		xform_printf(OF, "\t\t\t{\n");
+		xform_printf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
+		xform_printf(OF, "\t\t\t\t\"score\": %d\n", player->score);
+		xform_printf(OF, "\t\t\t}");
 		printed = 1;
 	}
 
-	fprintf(OF, "\n\t\t]");
+	xform_printf(OF, "\n\t\t]");
 }
+
+void json_display_starmade_player_info(struct qserver *server)
+{
+	struct player *player;
+	int printed = 0;
+
+	xform_printf(OF, ",\n\t\t\"players\": [\n");
+
+	player = server->players;
+	for (; player != NULL; player = player->next)
+	{
+		if (printed)
+		{
+			xform_printf(OF, ",\n");
+		}
+		xform_printf(OF, "\t\t\t{\n");
+		xform_printf(OF, "\t\t\t\t\"name\": \"%s\",\n", json_escape(xform_name(player->name, server)));
+		if (player->connect_time != 0)
+		{
+			xform_printf(OF, "\t\t\t\t\"time\": \"%s\",\n", json_escape(play_time(player->connect_time, 2)));
+		}
+		json_display_player_info_info(player);
+		xform_printf(OF, "\t\t\t\t\"ping\": %d\n", player->ping);
+		xform_printf(OF, "\t\t\t}");
+		printed = 1;
+	}
+
+	xform_printf(OF, "\n\t\t]");
+}
+
 
 void display_progress()
 {
@@ -3503,6 +3606,7 @@ void display_progress()
 		fprintf(stderr, "\r%d/%d (%d timed out, %d down)%s", num_servers_returned + num_servers_timed_out, num_servers_total, num_servers_timed_out, num_servers_down, rate);
 	}
 }
+
 
 /* ----- END MODIFICATION ----- Don't need to change anything below here. */
 
@@ -3555,21 +3659,19 @@ void usage(char *msg, char **argv, char *a1)
 	}
 
 	quicksort((void **)sorted_types, 0, n_server_types - 1, (int(*)(void *, void*))type_option_compare);
-
-
 	for (i = 0; i < n_server_types; i++)
 	{
 		type = sorted_types[i];
 		printf("%s\t\tquery %s server\n", type->type_option, type->game_name);
 	}
 
-	quicksort((void **)sorted_types, 0, n_server_types - 1, (int(*)(void *, void*))type_string_compare);
 	printf("-default\tset default server type:");
-	for (i = 0; i < n_server_types; type++, i++)
+	for (i = 0; i < n_server_types; i++)
 	{
 		type = sorted_types[i];
 		printf(" %s", type->type_string);
 	}
+
 	puts("");
 	printf("-nocfg\t\tIgnore qstat configuration loaded from any default location. Must be the first option on the command-line.\n");
 	printf("-cfg\t\tread the extended types from given file not the default one\n");
@@ -4253,11 +4355,11 @@ int main(int argc, char *argv[])
 		{
 			usage(NULL, argv, NULL);
 		}
-		else if (strcmp(argv[arg], "--json-protocols") == 0)
+		else if (strcmp(argv[arg], "-json-protocols") == 0)
 		{
 			json_protocols();
 		}
-		else if (strcmp(argv[arg], "--json-version") == 0)
+		else if (strcmp(argv[arg], "-json-version") == 0)
 		{
 			json_version();
 		}
@@ -13327,44 +13429,13 @@ char *json_escape(char *string)
 		c = *string;
 		switch (c)
 		{
-			/*case '&':
-				*b++ = '&';
-				*b++ = 'a';
-				*b++ = 'm';
-				*b++ = 'p';
-				*b++ = ';';
-				continue;
-			case '\'':
-				*b++ = '&';
-				*b++ = 'a';
-				*b++ = 'p';
-				*b++ = 'o';
-				*b++ = 's';
-				*b++ = ';';
-				continue;
-			case '"':
-				*b++ = '&';
-				*b++ = 'q';
-				*b++ = 'u';
-				*b++ = 'o';
-				*b++ = 't';
-				*b++ = ';';
-				continue;
-			case '<':
-				*b++ = '&';
-				*b++ = 'l';
-				*b++ = 't';
-				*b++ = ';';
-				continue;
-			case '>':
-				*b++ = '&';
-				*b++ = 'g';
-				*b++ = 't';
-				*b++ = ';';
-				continue;*/
 			case '"':
 				*b++ = '\\';
 				*b++ = '"';
+				continue;
+			case '\\':
+				*b++ = '\\';
+				*b++ = '\\';
 				continue;
 			default:
 				break;
@@ -13388,25 +13459,9 @@ char *json_escape(char *string)
 				fprintf(stderr, "Encoding error (%d) for U+%x, D+%d\n", 1, c, c);
 			}
 		}
-		else if (json_encoding == ENCODING_LATIN_1)
-		{
-			if (!name_xforms)
-			{
-				*b++ = c;
-			}
-			else
-			{
-				if (isprint(c))
-				{
-					*b++ = c;
-				}
-				else
-				{
-					b += sprintf( (char *)b, "&#%u;", c);
-				}
-			}
-		}
-		else if (json_encoding == ENCODING_UTF_8)
+		// JSON is always unicode-encoded, see RFC 4627
+		// https://www.ietf.org/rfc/rfc4627.txt
+		else
 		{
 			unsigned char tempbuf[10] =
 			{

--- a/qstat.h
+++ b/qstat.h
@@ -418,6 +418,8 @@ void json_display_tm_player_info( struct qserver *server);
 void json_display_wic_player_info( struct qserver *server);
 void json_display_fl_player_info( struct qserver *server);
 void json_display_tee_player_info( struct qserver *server);
+void json_display_ventrilo_player_info( struct qserver *server);
+void json_display_starmade_player_info( struct qserver *server);
 char *json_escape( char*);
 
 query_status_t send_qserver_request_packet( struct qserver *server);
@@ -3550,6 +3552,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,		/* display_raw_rule_func */
     xml_display_player_info,		/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
+    json_display_player_info,		/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_dirtybomb_request_packet,	/* status_query_func */
     NULL,							/* rule_query_func */
     NULL,							/* player_query_func */
@@ -3584,6 +3588,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,		/* display_raw_rule_func */
     xml_display_starmade_player_info,	/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
+    json_display_starmade_player_info,		/* display_json_player_func */
+    json_display_server_rules,				/* display_json_rule_func */
     send_starmade_request_packet,	/* status_query_func */
     NULL,							/* rule_query_func */
     NULL,							/* player_query_func */
@@ -3618,6 +3624,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,		/* display_raw_rule_func */
     xml_display_player_info,		/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
+    json_display_player_info,		/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_farmsim_request_packet,	/* status_query_func */
     NULL,							/* rule_query_func */
     NULL,							/* player_query_func */
@@ -3652,6 +3660,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,		/* display_raw_rule_func */
     xml_display_player_info,		/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
+    json_display_player_info,		/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_ksp_request_packet,		/* status_query_func */
     NULL,							/* rule_query_func */
     NULL,							/* player_query_func */

--- a/qstat.h
+++ b/qstat.h
@@ -389,6 +389,37 @@ void xml_display_ventrilo_player_info( struct qserver *server);
 void xml_display_starmade_player_info( struct qserver *server);
 char *xml_escape( char*);
 
+void json_display_server( struct qserver *server);
+void json_header();
+void json_footer();
+void json_display_server_rules( struct qserver *server);
+void json_display_player_info( struct qserver *server);
+void json_display_q_player_info( struct qserver *server);
+void json_display_qw_player_info( struct qserver *server);
+void json_display_q2_player_info( struct qserver *server);
+void json_display_unreal_player_info( struct qserver *server);
+void json_display_halflife_player_info( struct qserver *server);
+void json_display_tribes_player_info( struct qserver *server);
+void json_display_tribes2_player_info( struct qserver *server);
+void json_display_ravenshield_player_info( struct qserver *server);
+void json_display_savage_player_info( struct qserver *server);
+void json_display_farcry_player_info( struct qserver *server);
+void json_display_bfris_player_info( struct qserver *server);
+void json_display_descent3_player_info( struct qserver *server);
+void json_display_ghostrecon_player_info( struct qserver *server);
+void json_display_eye_player_info( struct qserver *server);
+void json_display_armyops_player_info( struct qserver *server);
+void json_display_player_info( struct qserver *server);
+void json_display_doom3_player_info( struct qserver *server);
+void json_display_ts2_player_info( struct qserver *server);
+void json_display_ts3_player_info( struct qserver *server);
+void json_display_bfbc2_player_info( struct qserver *server);
+void json_display_tm_player_info( struct qserver *server);
+void json_display_wic_player_info( struct qserver *server);
+void json_display_fl_player_info( struct qserver *server);
+void json_display_tee_player_info( struct qserver *server);
+char *json_escape( char*);
+
 query_status_t send_qserver_request_packet( struct qserver *server);
 query_status_t send_qwserver_request_packet( struct qserver *server);
 query_status_t send_ut2003_request_packet( struct qserver *server);
@@ -454,6 +485,8 @@ struct _server_type  {
     DisplayFunc display_raw_rule_func;
     DisplayFunc display_xml_player_func;
     DisplayFunc display_xml_rule_func;
+    DisplayFunc display_json_player_func;
+    DisplayFunc display_json_rule_func;
     QueryFunc status_query_func;
     QueryFunc rule_query_func;
     QueryFunc player_query_func;
@@ -921,6 +954,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_q_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_q_player_info,		/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_qserver_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -955,6 +990,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_q_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_q_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_qserver_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -989,6 +1026,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_qw_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_qw_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_qwserver_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -1023,6 +1062,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_qw_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_qw_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_qwserver_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -1057,6 +1098,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_q2_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_q2_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_qwserver_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -1091,6 +1134,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_q2_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_q2_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_qwserver_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -1125,6 +1170,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,		/* display_raw_rule_func */
     xml_display_doom3_player_info,	/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
+    json_display_doom3_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_qwserver_request_packet,	/* status_query_func */
     NULL,							/* rule_query_func */
     NULL,							/* player_query_func */
@@ -1159,6 +1206,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,		/* display_raw_rule_func */
     xml_display_halflife_player_info,	/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
+    json_display_halflife_player_info,	/* display_json_player_func */
+    json_display_server_rules,			/* display_json_rule_func */
     send_hl2_request_packet,		/* status_query_func */
     NULL,				/* rule_query_func */
     NULL,				/* player_query_func */
@@ -1193,6 +1242,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_q2_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_q2_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_qwserver_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -1227,6 +1278,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_q2_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_q2_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_qwserver_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -1261,6 +1314,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_q2_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_q2_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_qwserver_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -1295,6 +1350,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_unreal_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_unreal_player_info,	/* display_json_player_func */
+    json_display_server_rules,			/* display_json_rule_func */
     send_ut2003_request_packet,	/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -1329,6 +1386,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_unreal_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_unreal_player_info,	/* display_json_player_func */
+    json_display_server_rules,			/* display_json_rule_func */
     send_gps_request_packet,	/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -1363,6 +1422,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_halflife_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_halflife_player_info,	/* display_json_player_func */
+    json_display_server_rules,			/* display_json_rule_func */
     send_qwserver_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -1397,6 +1458,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_q2_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_q2_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_qwserver_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -1431,6 +1494,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_q2_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_q2_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_gps_request_packet,	/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -1465,6 +1530,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_tribes_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_tribes_player_info,	/* display_json_player_func */
+    json_display_server_rules,			/* display_json_rule_func */
     send_tribes_request_packet,	/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -1499,6 +1566,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_bfris_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_bfris_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_bfris_request_packet,	/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -1533,6 +1602,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_q2_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_q2_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_qwserver_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -1567,6 +1638,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_q2_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_q2_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_qwserver_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -1601,6 +1674,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_q2_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_q2_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_qwserver_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -1635,6 +1710,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_unreal_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_unreal_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_gps_request_packet,	/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -1669,6 +1746,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_tribes2_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_tribes2_player_info,	/* display_json_player_func */
+    json_display_server_rules,			/* display_json_rule_func */
     send_tribes2_request_packet,	/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -1703,6 +1782,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_descent3_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_descent3_player_info,	/* display_json_player_func */
+    json_display_server_rules,			/* display_json_rule_func */
     send_gps_request_packet,	/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -1737,6 +1818,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_descent3_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_descent3_player_info,	/* display_json_player_func */
+    json_display_server_rules,			/* display_json_rule_func */
     send_gps_request_packet,	/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -1771,6 +1854,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_descent3_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_descent3_player_info,	/* display_json_player_func */
+    json_display_server_rules,			/* display_json_rule_func */
     send_gps_request_packet,	/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -1805,6 +1890,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,		/* display_raw_rule_func */
     xml_display_ghostrecon_player_info,	/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
+    json_display_ghostrecon_player_info,	/* display_json_player_func */
+    json_display_server_rules,				/* display_json_rule_func */
     send_qserver_request_packet,	/* status_query_func */
     NULL,				/* rule_query_func */
     NULL,				/* player_query_func */
@@ -1839,6 +1926,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_eye_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_eye_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_qserver_request_packet,	/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -1873,6 +1962,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_player_info,	/* display_json_player_func */
+    json_display_server_rules,	/* display_json_rule_func */
     send_gs2_request_packet,	/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -1907,6 +1998,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_armyops_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_armyops_player_info,	/* display_json_player_func */
+    json_display_server_rules,			/* display_json_rule_func */
     send_gs2_request_packet,	/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -1941,6 +2034,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,		/* display_raw_rule_func */
     xml_display_ravenshield_player_info,	/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
+    json_display_ravenshield_player_info,	/* display_json_player_func */
+    json_display_server_rules,				/* display_json_rule_func */
     send_qserver_request_packet,	/* status_query_func */
     NULL,				/* rule_query_func */
     NULL,				/* player_query_func */
@@ -1975,6 +2070,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,		/* display_raw_rule_func */
     xml_display_savage_player_info,	/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
+    json_display_savage_player_info,	/* display_json_player_func */
+    json_display_server_rules,			/* display_json_rule_func */
     send_savage_request_packet,	/* status_query_func */
     NULL,				/* rule_query_func */
     NULL,				/* player_query_func */
@@ -2009,6 +2106,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,		/* display_raw_rule_func */
     xml_display_farcry_player_info,	/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
+    json_display_farcry_player_info,	/* display_json_player_func */
+    json_display_server_rules,			/* display_json_rule_func */
     send_farcry_request_packet,	/* status_query_func */
     NULL,				/* rule_query_func */
     NULL,				/* player_query_func */
@@ -2046,6 +2145,8 @@ server_type builtin_types[] = {
     NULL,	/* display_raw_rule_func */
     NULL,	/* display_xml_player_func */
     NULL,	/* display_xml_rule_func */
+    NULL,   /* display_json_player_func */
+    NULL,   /* display_json_rule_func */
     send_qwmaster_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -2080,6 +2181,8 @@ server_type builtin_types[] = {
     NULL,	/* display_raw_rule_func */
     NULL,	/* display_xml_player_func */
     NULL,	/* display_xml_rule_func */
+    NULL,   /* display_json_player_func */
+    NULL,   /* display_json_rule_func */
     send_qwmaster_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -2114,6 +2217,8 @@ server_type builtin_types[] = {
     NULL,	/* display_raw_rule_func */
     NULL,	/* display_xml_player_func */
     NULL,	/* display_xml_rule_func */
+    NULL,   /* display_json_player_func */
+    NULL,   /* display_json_rule_func */
     send_qwmaster_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -2148,6 +2253,8 @@ server_type builtin_types[] = {
     NULL,	/* display_raw_rule_func */
     NULL,	/* display_xml_player_func */
     NULL,	/* display_xml_rule_func */
+    NULL,   /* display_json_player_func */
+    NULL,   /* display_json_rule_func */
     send_qwmaster_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -2182,6 +2289,8 @@ server_type builtin_types[] = {
     NULL,	/* display_raw_rule_func */
     NULL,	/* display_xml_player_func */
     NULL,	/* display_xml_rule_func */
+    NULL,   /* display_json_player_func */
+    NULL,   /* display_json_rule_func */
     send_doom3master_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -2216,6 +2325,8 @@ server_type builtin_types[] = {
     NULL,	/* display_raw_rule_func */
     NULL,	/* display_xml_player_func */
     NULL,	/* display_xml_rule_func */
+    NULL,   /* display_json_player_func */
+    NULL,   /* display_json_rule_func */
     send_qwmaster_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -2250,6 +2361,8 @@ server_type builtin_types[] = {
     NULL,	/* display_raw_rule_func */
     NULL,	/* display_xml_player_func */
     NULL,	/* display_xml_rule_func */
+    NULL,   /* display_json_player_func */
+    NULL,   /* display_json_rule_func */
     send_qwmaster_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -2284,6 +2397,8 @@ server_type builtin_types[] = {
     NULL,	/* display_raw_rule_func */
     NULL,	/* display_xml_player_func */
     NULL,	/* display_xml_rule_func */
+    NULL,   /* display_json_player_func */
+    NULL,   /* display_json_rule_func */
     send_qwmaster_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -2318,6 +2433,8 @@ server_type builtin_types[] = {
     NULL,	/* display_raw_rule_func */
     NULL,	/* display_xml_player_func */
     NULL,	/* display_xml_rule_func */
+    NULL,   /* display_json_player_func */
+    NULL,   /* display_json_rule_func */
     send_qwmaster_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -2352,6 +2469,8 @@ server_type builtin_types[] = {
     NULL,	/* display_raw_rule_func */
     NULL,	/* display_xml_player_func */
     NULL,	/* display_xml_rule_func */
+    NULL,   /* display_json_player_func */
+    NULL,   /* display_json_rule_func */
     send_qwmaster_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -2386,6 +2505,8 @@ server_type builtin_types[] = {
     NULL,	/* display_raw_rule_func */
     NULL,	/* display_xml_player_func */
     NULL,	/* display_xml_rule_func */
+    NULL,   /* display_json_player_func */
+    NULL,   /* display_json_rule_func */
     send_gamespy_master_request,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -2420,6 +2541,8 @@ server_type builtin_types[] = {
     NULL,	/* display_raw_rule_func */
     NULL,	/* display_xml_player_func */
     NULL,	/* display_xml_rule_func */
+    NULL,   /* display_json_player_func */
+    NULL,   /* display_json_rule_func */
     send_tribes2master_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -2454,6 +2577,8 @@ server_type builtin_types[] = {
     NULL,	/* display_raw_rule_func */
     NULL,	/* display_xml_player_func */
     NULL,	/* display_xml_rule_func */
+    NULL,   /* display_json_player_func */
+    NULL,   /* display_json_rule_func */
     send_qwmaster_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -2488,6 +2613,8 @@ server_type builtin_types[] = {
     NULL,	/* display_raw_rule_func */
     NULL,	/* display_xml_player_func */
     NULL,	/* display_xml_rule_func */
+    NULL,   /* display_json_player_func */
+    NULL,   /* display_json_rule_func */
     send_qwmaster_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -2523,6 +2650,8 @@ server_type builtin_types[] = {
     NULL,	/* display_raw_rule_func */
     NULL,	/* display_xml_player_func */
     NULL,	/* display_xml_rule_func */
+    NULL,   /* display_json_player_func */
+    NULL,   /* display_json_rule_func */
     send_ut2004master_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -2557,6 +2686,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,		/* display_raw_rule_func */
     xml_display_halflife_player_info,	/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
+    json_display_halflife_player_info,	/* display_json_player_func */
+    json_display_server_rules,			/* display_json_rule_func */
     send_a2s_request_packet,		/* status_query_func */
     send_a2s_rule_request_packet,	/* rule_query_func */
     NULL,				/* player_query_func */
@@ -2591,6 +2722,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_unreal_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_unreal_player_info,	/* display_json_player_func */
+    json_display_server_rules,			/* display_json_rule_func */
     send_ut2003_request_packet,	/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -2625,6 +2758,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_player_info,	/* display_json_player_func */
+    json_display_server_rules,	/* display_json_rule_func */
     send_gs3_request_packet,	/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -2659,6 +2794,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,		/* display_raw_rule_func */
     xml_display_ts2_player_info,	/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
+    json_display_ts2_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_ts2_request_packet,		/* status_query_func */
     NULL,							/* rule_query_func */
     NULL,							/* player_query_func */
@@ -2693,6 +2830,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,		/* display_raw_rule_func */
     xml_display_doom3_player_info,	/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
+    json_display_doom3_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_qwserver_request_packet,	/* status_query_func */
     NULL,							/* rule_query_func */
     NULL,							/* player_query_func */
@@ -2727,6 +2866,8 @@ server_type builtin_types[] = {
     NULL,	/* display_raw_rule_func */
     NULL,	/* display_xml_player_func */
     NULL,	/* display_xml_rule_func */
+    NULL,   /* display_json_player_func */
+    NULL,   /* display_json_rule_func */
     send_quake4master_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -2761,6 +2902,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_gs3_request_packet,	/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -2795,6 +2938,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,		/* display_raw_rule_func */
     xml_display_doom3_player_info,	/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
+    json_display_doom3_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_qwserver_request_packet,	/* status_query_func */
     NULL,							/* rule_query_func */
     NULL,							/* player_query_func */
@@ -2829,6 +2974,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,		/* display_raw_rule_func */
     xml_display_tm_player_info,		/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
+    json_display_tm_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_tm_request_packet,			/* status_query_func */
     NULL,							/* rule_query_func */
     NULL,							/* player_query_func */
@@ -2863,6 +3010,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,		/* display_raw_rule_func */
     xml_display_doom3_player_info,	/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
+    json_display_doom3_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_qwserver_request_packet,	/* status_query_func */
     NULL,							/* rule_query_func */
     NULL,							/* player_query_func */
@@ -2897,6 +3046,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_player_info,	/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_player_info,	/* display_json_player_func */
+    json_display_server_rules,	/* display_json_rule_func */
     send_haze_request_packet,	/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -2931,6 +3082,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,		/* display_raw_rule_func */
     xml_display_wic_player_info,	/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
+    json_display_wic_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_wic_request_packet,		/* status_query_func */
     NULL,							/* rule_query_func */
     NULL,							/* player_query_func */
@@ -2965,6 +3118,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,	/* display_raw_rule_func */
     xml_display_player_info,/* display_xml_player_func */
     xml_display_server_rules,	/* display_xml_rule_func */
+    json_display_player_info,	/* display_json_player_func */
+    json_display_server_rules,	/* display_json_rule_func */
     send_ottd_request_packet,	/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -2999,6 +3154,8 @@ server_type builtin_types[] = {
     NULL,	/* display_raw_rule_func */
     NULL,	/* display_xml_player_func */
     NULL,	/* display_xml_rule_func */
+    NULL,   /* display_json_player_func */
+    NULL,   /* display_json_rule_func */
     send_ottdmaster_request_packet,/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */
@@ -3033,6 +3190,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,		/* display_raw_rule_func */
     xml_display_fl_player_info,	/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
+    json_display_fl_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_fl_request_packet,			/* status_query_func */
     send_fl_rule_request_packet,	/* rule_query_func */
 	NULL,							/* player_query_func */
@@ -3067,6 +3226,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,		/* display_raw_rule_func */
     xml_display_doom3_player_info,	/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
+    json_display_doom3_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_qwserver_request_packet,	/* status_query_func */
     NULL,							/* rule_query_func */
     NULL,							/* player_query_func */
@@ -3101,6 +3262,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,		/* display_raw_rule_func */
     xml_display_tee_player_info,		/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
+    json_display_tee_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_tee_request_packet,			/* status_query_func */
     NULL,							/* rule_query_func */
     NULL,							/* player_query_func */
@@ -3135,6 +3298,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,		/* display_raw_rule_func */
     xml_display_ts3_player_info,	/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
+    json_display_ts3_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_ts3_request_packet,		/* status_query_func */
     NULL,							/* rule_query_func */
     NULL,							/* player_query_func */
@@ -3169,6 +3334,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,		/* display_raw_rule_func */
     xml_display_bfbc2_player_info,	/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
+    json_display_bfbc2_player_info,	/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_bfbc2_request_packet,		/* status_query_func */
     NULL,							/* rule_query_func */
     NULL,							/* player_query_func */
@@ -3203,6 +3370,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,			/* display_raw_rule_func */
     xml_display_ventrilo_player_info,	/* display_xml_player_func */
     xml_display_server_rules,			/* display_xml_rule_func */
+    json_display_ventrilo_player_info,	/* display_json_player_func */
+    json_display_server_rules,			/* display_json_rule_func */
     send_ventrilo_request_packet,		/* status_query_func */
     NULL,								/* rule_query_func */
     NULL,								/* player_query_func */
@@ -3237,6 +3406,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,			/* display_raw_rule_func */
     NULL,								/* display_xml_player_func */
     xml_display_server_rules,			/* display_xml_rule_func */
+    NULL,                               /* display_json_player_func */
+    json_display_server_rules,			/* display_json_rule_func */
     send_cube2_request_packet,			/* status_query_func */
     NULL,								/* rule_query_func */
     NULL,								/* player_query_func */
@@ -3271,6 +3442,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,		/* display_raw_rule_func */
     xml_display_player_info,		/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
+    json_display_player_info,		/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_mumble_request_packet,		/* status_query_func */
     NULL,							/* rule_query_func */
     NULL,							/* player_query_func */
@@ -3305,6 +3478,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,		/* display_raw_rule_func */
     xml_display_player_info,		/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
+    json_display_player_info,		/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_mumble_request_packet,		/* status_query_func */
     NULL,							/* rule_query_func */
     NULL,							/* player_query_func */
@@ -3339,6 +3514,8 @@ server_type builtin_types[] = {
     raw_display_server_rules,		/* display_raw_rule_func */
     xml_display_player_info,		/* display_xml_player_func */
     xml_display_server_rules,		/* display_xml_rule_func */
+    json_display_player_info,		/* display_json_player_func */
+    json_display_server_rules,		/* display_json_rule_func */
     send_crysis_request_packet,		/* status_query_func */
     NULL,							/* rule_query_func */
     NULL,							/* player_query_func */
@@ -3542,6 +3719,8 @@ server_type builtin_types[] = {
     NULL,			/* display_raw_rule_func */
     NULL,			/* display_xml_player_func */
     NULL,			/* display_xml_rule_func */
+    NULL,           /* display_json_player_func */
+    NULL,           /* display_json_rule_func */
     NULL,			/* status_query_func */
     NULL,			/* rule_query_func */
     NULL,			/* player_query_func */


### PR DESCRIPTION
Hi @stevenh, this PR imports patches from the @eXprojects's qstat-json fork.

This fork was based on a source tarball, so was amnesic to all the revision history, also, this fork included mistakenly some temporary build files.

I've rewritten by hand the two useful patches and I committed them with the original `author` (`Steve Teuber <steve<ad>exprojects.org>`) and the original `author date` for each commit.

After that I've modified the source to add json support to games that were added since the release  tarball Steve used (like `starmade`, `dirtybomb`, `farmsim` and `ksp`) and fixed the `ventrilo` omission he did.

After that I renamed `name_xfroms` to `xform_names` and used xform_printf() instead of fprintf() in json code, like in e777674 (_Refactored output splitting out xform processing into its own files improving various portions of it._)

So, some intermediate commits cannot build, but the whole PR builds. I think we can't do better than that without rewriting Steve's commits, which raises legal issues: it must be clear to know who have done what and when.

@skybon, you will probably be interested by this PR.
