### PR TITLE
iterator limit now match malloc in protocol listing, fix #21, ref #13

### DIFF
--- a/qstat.c
+++ b/qstat.c
@@ -2654,7 +2654,7 @@ void usage(char *msg, char **argv, char *a1)
 
 	sorted_types = (server_type **)malloc(sizeof(server_type*) * n_server_types);
 	type = &types[0];
-	for (i = 0; type->id != Q_UNKNOWN_TYPE; type++, i++)
+	for (i = 0; type->id != Q_UNKNOWN_TYPE && i < n_server_types; type++, i++)
 	{
 		sorted_types[i] = type;
 	}


### PR DESCRIPTION
Hi, the `for` test now checks if `i < n_server_types`, even if `Q_UNKNOWN_TYPE` is always the last gametype.

* fix the issue #21, needed by PR #13 .

This issue is more than 13 years old, but since  `Q_UNKNOWN_TYPE` is always the last gametype, no problem has never occured.