### PR TITLE
Config: bump default OpenArena protocol version

### DIFF
--- a/qstat.cfg
+++ b/qstat.cfg
@@ -371,7 +371,7 @@ gametype OPENARENAM new extend Q3M
     template var = OPENARENAMASTER
     default port = 27950
     master packet = \377\377\377\377getservers %s %s
-    master protocol = 70
+    master protocol = 71
     master query = empty full
     master for gametype = OPENARENAS
 end


### PR DESCRIPTION
OpenArena 0.8.5 changed its protocol version to 71 which makes current QStat default config dysfunctional. This PR fixes it.