### PR TITLE
Fix a2s player query

### DIFF
--- a/a2s.c
+++ b/a2s.c
@@ -86,11 +86,11 @@ query_status_t send_a2s_rule_request_packet(struct qserver *server)
 
 			// Challenge Request was broken so instead we use a player request with an invalid
 			// challenge which prompts the server to send a valid challenge
-			// This was fixed as of the update 2009-08-26
-			//char buf[sizeof(A2S_PLAYER)-1+4] = A2S_PLAYER;
-			//memcpy( buf + sizeof(A2S_PLAYER)-1, &status->challenge, 4 );
-			//if( SOCKET_ERROR == qserver_send_initial(server, buf, sizeof(buf)) )
-			if( SOCKET_ERROR == qserver_send_initial(server, A2S_GETCHALLENGE, sizeof(A2S_GETCHALLENGE)-1) )
+			// This was fixed as of the update 2009-08-26 but then subsiquently broken again.
+			//if( SOCKET_ERROR == qserver_send_initial(server, A2S_GETCHALLENGE, sizeof(A2S_GETCHALLENGE)-1) )
+			char buf[sizeof(A2S_PLAYER)-1+4] = A2S_PLAYER;
+			memcpy( buf + sizeof(A2S_PLAYER)-1, &status->challenge, 4 );
+			if( SOCKET_ERROR == qserver_send_initial(server, buf, sizeof(buf)) )
 			{
 				return SOCKET_ERROR;
 			}


### PR DESCRIPTION
Fix a2s player query again which has been broken by source updates again.

We again use the alternative method of requesting players with an invalid challenge.

This fixes #46.