### PR TITLE
add 'uncrustify' rule to Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -55,3 +55,6 @@ EXTRA_DIST = CHANGES.txt COMPILE.txt LICENSE.txt \
 cl:
 	cvs2cl.pl --utc --no-wrap --separate-header --no-times -f ChangeLog.cvs
 	rm -f ChangeLog.cvs.bak qstat.core
+
+uncrustify:
+	uncrustify --no-backup -c 'uncrustify.cfg' -l c $(qstat_SOURCES)

--- a/qstat.h
+++ b/qstat.h
@@ -520,11 +520,13 @@ server_type *find_server_type_string(char *type_string);
 		Q_FLAG1, Q_FLAG2, Q_SERVERINFO_LEN, Q_CCREQ_SERVER_INFO, "QUAKE\000\003"
 	};
 
-	struct q_packet q_rule = {
+	struct q_packet q_rule =
+	{
 		Q_FLAG1, Q_FLAG2, 0, Q_CCREQ_RULE_INFO, ""
 	};
 
-	struct q_packet q_player = {
+	struct q_packet q_player =
+	{
 		Q_FLAG1, Q_FLAG2, 6, Q_CCREQ_PLAYER_INFO, ""
 	};
 


### PR DESCRIPTION
uncrustify made easy: use `make uncrustify` (`configure` must be run before).

an extra commit ships two previously missed format issues in `qstat.h`, fixed by uncrustify, this way future uncrustify run will not include them in unrelated commits.