### PR TITLE
Update tf to support v4 protocol

### DIFF
--- a/display_json.c
+++ b/display_json.c
@@ -681,6 +681,9 @@ json_display_player_info(struct qserver *server)
 		if (player->connect_time != 0) {
 			xform_printf(OF, "\t\t\t\t\"time\": \"%s\",\n", json_escape(play_time(player->connect_time, 1)));
 		}
+		if (player->address != NULL) {
+			xform_printf(OF, "\t\t\t\t\"address\": \"%s\",\n", json_escape(player->address));
+		}
 		json_display_player_info_info(player);
 		xform_printf(OF, "\t\t\t\t\"name\": \"%s\"\n", json_escape(xform_name(player->name, server)));
 		xform_printf(OF, "\t\t\t}");

--- a/qstat.c
+++ b/qstat.c
@@ -2249,6 +2249,10 @@ xml_display_player_info(struct qserver *server)
 			xform_printf(OF, "\t\t\t\t<time>%s</time>\n", xml_escape(play_time(player->connect_time, 1)));
 		}
 
+		if (player->address) {
+			xform_printf(OF, "\t\t\t\t<address>%s</address>\n", xml_escape(player->address));
+		}
+
 		xml_display_player_info_info(player);
 
 		xform_printf(OF, "\t\t\t</player>\n");

--- a/qstat.h
+++ b/qstat.h
@@ -3687,7 +3687,7 @@ server_type *find_server_type_string(char *type_string);
 			0,                              /* default_port */
 			0,                              /* port_offset */
 			0,                              /* flags */
-			"gamerules",                    /* game_rule */
+			"game_mode",                    /* game_rule */
 			"TFPROTOCOL",                   /* template_var */
 			NULL,                           /* status_packet */
 			0,                              /* status_len */
@@ -3705,8 +3705,8 @@ server_type *find_server_type_string(char *type_string);
 			raw_display_server_rules,       /* display_raw_rule_func */
 			xml_display_player_info,        /* display_xml_player_func */
 			xml_display_server_rules,       /* display_xml_rule_func */
-			NULL,                           /* display_json_player_func */
-			NULL,                           /* display_json_rule_func */
+			json_display_player_info,       /* display_json_player_func */
+			json_display_server_rules,      /* display_json_rule_func */
 			send_tf_request_packet,         /* status_query_func */
 			NULL,                           /* rule_query_func */
 			NULL,                           /* player_query_func */

--- a/tf.c
+++ b/tf.c
@@ -13,10 +13,18 @@
 #include "utils.h"
 
 #include <stdio.h>
+#include <netinet/in.h>
+#include <inttypes.h>
+#include <string.h>
 
-#define SERVERINFO_REQUEST	79
-#define SERVERINFO_VERSION	1
-#define SERVERINFO_RESPONSE	80
+#define SERVERINFO_REQUEST		79
+#define SERVERINFO_RESPONSE		80
+#define SERVERINFO_VERSION		3
+#define SERVERINFO_VERSION_KEYED	4
+#define TEAM_IMC			"imc"
+#define TEAM_MILITIA			"militia"
+#define TEAM_UNKNOWN			"unknown"
+#define SERVER_NAME			"unknown"
 
 static char serverinfo_pkt[] = { 0xFF, 0xFF, 0xFF, 0xFF, SERVERINFO_REQUEST, SERVERINFO_VERSION };
 
@@ -29,11 +37,11 @@ pkt_inc(char **pkt, int *rem, int inc)
 
 
 static query_status_t
-pkt_string(struct qserver *server, char **pkt, char **str, int *rem)
+pkt_string(struct qserver *server, char **pkt, int *rem, char **str, char *rule)
 {
 	size_t len;
 
-	if (*rem <= 0) {
+	if (*rem < 0) {
 		malformed_packet(server, "short packet");
 		return (PKT_ERROR);
 	}
@@ -47,43 +55,120 @@ pkt_string(struct qserver *server, char **pkt, char **str, int *rem)
 	len = strlen(*str) + 1;
 	pkt_inc(pkt, rem, (int)len);
 
+	if (rule != NULL) {
+		// TODO: check return when it doesn't exit on failure
+		add_rule(server, rule, *str, NO_VALUE_COPY);
+	}
+
 	return (INPROGRESS);
 }
 
 
 static query_status_t
-pkt_rule(struct qserver *server, char *rule, char **pkt, int *rem)
+pkt_rule(struct qserver *server, char **pkt, int *rem, char *rule)
 {
 	char *str;
-	query_status_t ret;
 
-	ret = pkt_string(server, pkt, &str, rem);
-	if (ret < 0) {
-		return (ret);
+	return (pkt_string(server, pkt, rem, &str, rule));
+}
+
+
+static query_status_t
+pkt_data(struct qserver *server, char **pkt, int *rem, void *data, char *rule, int size)
+{
+	if (*rem - size < 0) {
+		malformed_packet(server, "short packet");
+		return (PKT_ERROR);
 	}
 
-	// TODO: check return when it doesn't exit on failure
-	add_rule(server, rule, str, NO_VALUE_COPY);
+	memcpy(data, *pkt, size);
+	pkt_inc(pkt, rem, size);
+
+	if (rule != NULL) {
+		char buf[64];
+
+		switch (size) {
+		case 1:
+			sprintf(buf, "%hhu", (uint8_t)data);
+			break;
+
+		case 2:
+			sprintf(buf, "%hu", (uint16_t)data);
+			break;
+
+		case 4:
+			sprintf(buf, "%" PRIu32, (uint32_t)data);
+			break;
+
+		case 8:
+			sprintf(buf, "%" PRIu64, (uint64_t)data);
+			break;
+		}
+		add_rule(server, rule, buf, 0);
+	}
 
 	return (INPROGRESS);
+}
+
+
+static query_status_t
+pkt_byte(struct qserver *server, char **pkt, int *rem, uint8_t *data, char *rule)
+{
+	return (pkt_data(server, pkt, rem, (void *)data, rule, sizeof(*data)));
+}
+
+
+static query_status_t
+pkt_short(struct qserver *server, char **pkt, int *rem, uint16_t *data, char *rule)
+{
+	return (pkt_data(server, pkt, rem, (void *)data, rule, sizeof(*data)));
+}
+
+
+static query_status_t
+pkt_long(struct qserver *server, char **pkt, int *rem, uint32_t *data, char *rule)
+{
+	return (pkt_data(server, pkt, rem, (void *)data, rule, sizeof(*data)));
+}
+
+
+static query_status_t
+pkt_longlong(struct qserver *server, char **pkt, int *rem, uint64_t *data, char *rule)
+{
+	return (pkt_data(server, pkt, rem, (void *)data, rule, sizeof(*data)));
 }
 
 
 query_status_t
 send_tf_request_packet(struct qserver *server)
 {
-	return (qserver_send_initial(server, serverinfo_pkt, sizeof(serverinfo_pkt)));
+	char *key, buf[64];
+
+	key = get_param_value(server, "key", NULL);
+	if (key == NULL) {
+		return (qserver_send_initial(server, serverinfo_pkt, sizeof(serverinfo_pkt)));
+	}
+
+	memcpy(buf, serverinfo_pkt, sizeof(serverinfo_pkt));
+	buf[5] = SERVERINFO_VERSION_KEYED;
+	(void)strncpy(&buf[6], key, sizeof(buf) - 7);
+	// strncpy doesn't garantee to NULL terminate and strlcpy isn't portable.
+	buf[sizeof(buf) - 1] = '\0';
+
+	return (qserver_send_initial(server, buf, sizeof(serverinfo_pkt) + strlen(key) + 1));
 }
 
 
 query_status_t
 deal_with_tf_packet(struct qserver *server, char *rawpkt, int pktlen)
 {
-	char *pkt, *str, buf[16];
+	char *pkt, buf[64];
 	query_status_t ret;
-	uint16_t port;
 	int rem, i;
-	int32_t num;
+	uint8_t ver, tmpu8;
+	uint16_t port, tmpu16;
+	uint32_t tmpu32;
+	uint64_t tmpu64;
 
 	rem = pktlen;
 	pkt = rawpkt;
@@ -113,60 +198,187 @@ deal_with_tf_packet(struct qserver *server, char *rawpkt, int pktlen)
 	}
 	pkt_inc(&pkt, &rem, sizeof(int8_t));
 
-	// Version (int8)
-	sprintf(buf, "%hhd", *pkt);
-	add_rule(server, "version", buf, 0);
-	pkt_inc(&pkt, &rem, sizeof(int8_t));
+	// Version (byte)
+	debug(2, "TF version = %hhu", *pkt);
+	ret = pkt_byte(server, &pkt, &rem, &ver, "version");
+	if (ret < 0) {
+		return (ret);
+	}
 
-	// Port (uint16)
-	port = (uint16_t)((unsigned char)pkt[0] | (unsigned char)pkt[1] << 8);
-	sprintf(buf, "%hu", port);
-	add_rule(server, "port", buf, 0);
+	if (ver > 1) {
+		// Retail (byte)
+		ret = pkt_byte(server, &pkt, &rem, &tmpu8, "retail");
+		if (ret < 0) {
+			return (ret);
+		}
+
+		// Instance Type (byte)
+		ret = pkt_byte(server, &pkt, &rem, &tmpu8, "instance_type");
+		if (ret < 0) {
+			return (ret);
+		}
+
+		// Client DLL CRC (long)
+		ret = pkt_long(server, &pkt, &rem, &tmpu32, "client_dll_crc");
+		if (ret < 0) {
+			return (ret);
+		}
+
+		// Net Prototcol (short)
+		ret = pkt_short(server, &pkt, &rem, &tmpu16, "net_protocol");
+		if (ret < 0) {
+			return (ret);
+		}
+
+		// Random ServerID (long long)
+		ret = pkt_longlong(server, &pkt, &rem, &tmpu64, "random_serverid");
+		if (ret < 0) {
+			return (ret);
+		}
+
+		// Build Name (string)
+		ret = pkt_rule(server, &pkt, &rem, "build_name");
+		if (ret < 0) {
+			return (ret);
+		}
+
+		// Datacenter (string)
+		ret = pkt_rule(server, &pkt, &rem, "datacenter");
+		if (ret < 0) {
+			return (ret);
+		}
+
+		// Game Mode (string)
+		ret = pkt_rule(server, &pkt, &rem, "game_mode");
+		if (ret < 0) {
+			return (ret);
+		}
+	}
+
+	// Port (short)
+	ret = pkt_short(server, &pkt, &rem, &port, "port");
+	if (ret < 0) {
+		return (ret);
+	}
 	change_server_port(server, port, 0);
-	pkt_inc(&pkt, &rem, sizeof(uint16_t));
 
 	// Platform (string)
-	ret = pkt_rule(server, "platform", &pkt, &rem);
+	ret = pkt_rule(server, &pkt, &rem, "platform");
 	if (ret < 0) {
 		return (ret);
 	}
 
 	// Playlist Version (string)
-	ret = pkt_rule(server, "playlist_version", &pkt, &rem);
+	ret = pkt_rule(server, &pkt, &rem, "playlist_version");
 	if (ret < 0) {
 		return (ret);
 	}
 
-	// Playlist Num (int32)
-	num = (int32_t)(
-		(unsigned char)pkt[0] |
-		(unsigned char)pkt[1] << 8 |
-		(unsigned char)pkt[2] << 16 |
-		(unsigned char)pkt[3] << 24
-		);
-	sprintf(buf, "%d", num);
-	add_rule(server, "playlist_num", buf, 0);
-	pkt_inc(&pkt, &rem, sizeof(int32_t));
+	// Playlist Num (long)
+	ret = pkt_long(server, &pkt, &rem, &tmpu32, "playlist_num");
+	if (ret < 0) {
+		return (ret);
+	}
 
 	// Playlist Name (string)
-	ret = pkt_rule(server, "playlist_name", &pkt, &rem);
+	ret = pkt_rule(server, &pkt, &rem, "playlist_name");
 	if (ret < 0) {
 		return (ret);
 	}
 
-	// Num Clients (uint8)
-	server->num_players = (uint8_t)pkt[0];
-
-	// Max Clients (uint8)
-	server->max_players = (uint8_t)pkt[1];
-	pkt_inc(&pkt, &rem, sizeof(uint8_t) * 2);
-
-	// Map (string)
-	ret = pkt_string(server, &pkt, &str, &rem);
+	// Num Clients (byte)
+	ret = pkt_byte(server, &pkt, &rem, (uint8_t *)&server->num_players, NULL);
 	if (ret < 0) {
 		return (ret);
 	}
-	server->map_name = str;
+
+	// Max Clients (byte)
+	ret = pkt_byte(server, &pkt, &rem, (uint8_t *)&server->max_players, NULL);
+	if (ret < 0) {
+		return (ret);
+	}
+
+	// Map Name (string)
+	ret = pkt_string(server, &pkt, &rem, &server->map_name, NULL);
+	if (ret < 0) {
+		return (ret);
+	}
+
+	if (ver > 2) {
+		// Phase (byte)
+		ret = pkt_byte(server, &pkt, &rem, &tmpu8, "phase");
+		if (ret < 0) {
+			return (ret);
+		}
+
+		// Max Rounds (byte)
+		ret = pkt_byte(server, &pkt, &rem, &tmpu8, "max_rounds");
+		if (ret < 0) {
+			return (ret);
+		}
+
+		// Rounds Won IMC (byte)
+		ret = pkt_byte(server, &pkt, &rem, &tmpu8, "rounds_won_imc");
+		if (ret < 0) {
+			return (ret);
+		}
+
+		// Rounds Won Militia (byte)
+		ret = pkt_byte(server, &pkt, &rem, &tmpu8, "rounds_won_militia");
+		if (ret < 0) {
+			return (ret);
+		}
+
+		// Time Limit Sec (short)
+		ret = pkt_short(server, &pkt, &rem, &tmpu16, "time_limit_sec");
+		if (ret < 0) {
+			return (ret);
+		}
+
+		// Time Passed Sec (short)
+		ret = pkt_short(server, &pkt, &rem, &tmpu16, "time_passed_sec");
+		if (ret < 0) {
+			return (ret);
+		}
+
+		// Max Score (short)
+		ret = pkt_short(server, &pkt, &rem, &tmpu16, "max_score");
+		if (ret < 0) {
+			return (ret);
+		}
+
+		// Team (byte)
+		ret = pkt_byte(server, &pkt, &rem, &tmpu8, NULL);
+		if (ret < 0) {
+			return (ret);
+		}
+
+		while (tmpu8 != 255) {
+			// Team Score (short)
+			ret = pkt_short(server, &pkt, &rem, &tmpu16, NULL);
+			if (ret < 0) {
+				return (ret);
+			}
+			sprintf(buf, "%hu", tmpu16);
+			switch (tmpu8) {
+			case 2:
+				add_rule(server, "imc_score", buf, 0);
+				add_rule(server, "imc_teamid", "2", 0);
+				break;
+
+			case 3:
+				add_rule(server, "militia_score", buf, 0);
+				add_rule(server, "militia_teamid", "3", 0);
+				break;
+			}
+
+			// Next team (byte)
+			ret = pkt_byte(server, &pkt, &rem, &tmpu8, NULL);
+			if (ret < 0) {
+				return (ret);
+			}
+		}
+	}
 
 	// Clients
 	for (i = 0; i < server->num_players; i++) {
@@ -177,29 +389,112 @@ deal_with_tf_packet(struct qserver *server, char *rawpkt, int pktlen)
 			// Should never happen
 			return (SYS_ERROR);
 		}
+		p->flags = PLAYER_FLAG_DO_NOT_FREE_TEAM;
 
-		// Client ID (int64)
-		pkt_inc(&pkt, &rem, sizeof(int64_t));
+		// Client ID (uint64)
+		ret = pkt_longlong(server, &pkt, &rem, &tmpu64, NULL);
+		if (ret < 0) {
+			return (ret);
+		}
+		sprintf(buf, "%" PRIu64, tmpu64);
+		player_add_info(p, "id", buf, 0);
 
 		// Client Name (string)
-		ret = pkt_string(server, &pkt, &p->name, &rem);
+		ret = pkt_string(server, &pkt, &rem, &p->name, NULL);
 		if (ret < 0) {
 			return (ret);
 		}
 
-		// Client Team ID (uint8)
-		p->team = (uint8_t)*pkt;
-		pkt_inc(&pkt, &rem, sizeof(uint8_t));
+		// Client Team ID (byte)
+		ret = pkt_byte(server, &pkt, &rem, &tmpu8, NULL);
+		if (ret < 0) {
+			return (ret);
+		}
+		p->team = tmpu8;
+		switch (tmpu8) {
+		case 2:
+			p->team_name = TEAM_IMC;
+			break;
+
+		case 3:
+			p->team_name = TEAM_MILITIA;
+			break;
+
+		default:
+			p->team_name = TEAM_UNKNOWN;
+			break;
+		}
+		sprintf(buf, "%hhu", tmpu8);
+		player_add_info(p, "teamid", buf, 0);
+
+		if (ver > 3) {
+			// Client Address (string)
+			ret = pkt_string(server, &pkt, &rem, &p->address, NULL);
+			if (ret < 0) {
+				return (ret);
+			}
+
+			// Client Ping (long)
+			ret = pkt_long(server, &pkt, &rem, &tmpu32, NULL);
+			if (ret < 0) {
+				return (ret);
+			}
+			p->ping = tmpu32;
+
+			// Client Incoming Packets Received (long)
+			ret = pkt_long(server, &pkt, &rem, &tmpu32, NULL);
+			if (ret < 0) {
+				return (ret);
+			}
+			sprintf(buf, "%" PRIu32, tmpu32);
+			player_add_info(p, "incoming_packets_received", buf, 0);
+
+			// Client Incoming Packets Dropped (long)
+			ret = pkt_long(server, &pkt, &rem, &tmpu32, NULL);
+			if (ret < 0) {
+				return (ret);
+			}
+			sprintf(buf, "%" PRIu32, tmpu32);
+			player_add_info(p, "incoming_packets_dropped", buf, 0);
+		}
+
+		if (ver > 2) {
+			// Client Score (long)
+			ret = pkt_long(server, &pkt, &rem, &tmpu32, NULL);
+			if (ret < 0) {
+				return (ret);
+			}
+			p->score = tmpu32;
+
+			// Client Kills (short)
+			ret = pkt_short(server, &pkt, &rem, &tmpu16, NULL);
+			if (ret < 0) {
+				return (ret);
+			}
+			p->frags = tmpu16;
+
+			// Client Deaths (short)
+			ret = pkt_short(server, &pkt, &rem, &tmpu16, NULL);
+			if (ret < 0) {
+				return (ret);
+			}
+			p->deaths = tmpu16;
+		}
 	}
 
-	// EOP (int64)
-	if (rem != 8) {
-		malformed_packet(server, "packet too short");
+	// EOP (long long)
+	ret = pkt_longlong(server, &pkt, &rem, &tmpu64, NULL);
+	if (ret < 0) {
+		return (ret);
+	}
+
+	if (tmpu64 != 0) {
+		malformed_packet(server, "none zero EOP");
 		return (PKT_ERROR);
 	}
 
 	// Protocol doesn't support server name
-	server->server_name = strdup("unknown");
+	server->server_name = strdup(SERVER_NAME);
 
 	// Protocol doesn't support a specific rule request
 	server->next_rule = NULL;


### PR DESCRIPTION
Update tf to support v3 / v4 protocol.

If a key is specified v4 protocol is used otherwise v3 protocol is used for compatiblity as v4 is not fully deployed.

This also refactors the way details are read making use of common pkt_XXX methods which validate the packet is valid for the given request.

Also:
* Enable json output of player and rule information for tf.