### PR TITLE
Fixed ts3 login parameter order

### DIFF
--- a/ts3.c
+++ b/ts3.c
@@ -110,7 +110,7 @@ send_ts3_single_server_packet(struct qserver *server)
 		password = get_param_value(server, "password", "");
 		if (0 != strlen(password)) {
 			username = get_param_value(server, "username", "serveradmin");
-			sprintf(buf, "login %s %s\015\012", password, username);
+			sprintf(buf, "login %s %s\015\012", username, password);
 			break;
 		}
 		// NOTE: no break so we fall through


### PR DESCRIPTION
Corrected the parameter order for teamspeak 3 login command for single server requests which was inverted.