### PR TITLE
Fixed titanfall protocol handling of ints

### DIFF
--- a/Makefile.noauto
+++ b/Makefile.noauto
@@ -87,4 +87,4 @@ os2emx: $(SRC)
 	$(CC) $(CFLAGS) -o qstat.exe $(SRC) $(LDFLAGS) $(LDLIBS) $(EMX_LIBS)
 
 clean:
-	rm -f qstat core qstat.exe $(O) $(OBJ)
+	rm -f qstat core qstat.exe *.pdb $(O) $(OBJ)

--- a/qstat.h
+++ b/qstat.h
@@ -54,7 +54,9 @@
  #ifndef EADDRINUSE
 		#define EADDRINUSE	WSAEADDRINUSE
  #endif
+ #if _MSC_VER < 1900
 	#define snprintf		_snprintf
+ #endif
 #else
  #include <sys/time.h>
 	#define SOCKET_ERROR		-1

--- a/tf.c
+++ b/tf.c
@@ -13,7 +13,11 @@
 #include "utils.h"
 
 #include <stdio.h>
-#include <netinet/in.h>
+#ifndef _WIN32
+ #include <netinet/in.h>
+#else
+ #include <winsock.h>
+#endif
 #include <inttypes.h>
 #include <string.h>
 
@@ -89,19 +93,19 @@ pkt_data(struct qserver *server, char **pkt, int *rem, void *data, char *rule, i
 
 		switch (size) {
 		case 1:
-			sprintf(buf, "%hhu", (uint8_t)data);
+			sprintf(buf, "%hhu", *(uint8_t*)data);
 			break;
 
 		case 2:
-			sprintf(buf, "%hu", (uint16_t)data);
+			sprintf(buf, "%hu", *(uint16_t*)data);
 			break;
 
 		case 4:
-			sprintf(buf, "%" PRIu32, (uint32_t)data);
+			sprintf(buf, "%" PRIu32, *(uint32_t*)data);
 			break;
 
 		case 8:
-			sprintf(buf, "%" PRIu64, (uint64_t)data);
+			sprintf(buf, "%" PRIu64, *(uint64_t*)data);
 			break;
 		}
 		add_rule(server, rule, buf, 0);


### PR DESCRIPTION
Fixed titanfall incorrect handling of integer types.

Also:
* Fixed compilation under titanfall compilation under VC++
* Fixed compilation under later versions of VC++ which define snprintf and not just _snprintf.
* Added removal of VC++ *.pdb files in clean target of noauto.