### PR TITLE
OpenBSD fixes

### DIFF
--- a/utils.h
+++ b/utils.h
@@ -12,7 +12,7 @@
 #endif
 
 // BSD has strnstr
-#if defined(__FreeBSD__) || defined(__MidnightBSD__) || defined(__OpenBSD__)
+#if defined(__FreeBSD__) || defined(__MidnightBSD__)
  #ifndef HAVE_STRNSTR
 		#define HAVE_STRNSTR    1
  #endif         /* HAVE_STRNSTR */

--- a/ventrilo.c
+++ b/ventrilo.c
@@ -15,7 +15,11 @@
  #include <netinet/in.h>
  #include <arpa/inet.h>
 	#define strtok_ret		strtok_r
+	#ifdef __OpenBSD__
+	#define VENTRILO_RAND		arc4random()
+	#else
 	#define VENTRILO_RAND		random()
+	#endif
 #else
  #include <winsock.h>
 	#define strtok_ret		strtok_s


### PR DESCRIPTION
Hi,
   I've got some OpenBSD fixes here. OpenBSD has never had strnstr() (it's in the FreeBSD API not OpenBSD), and added an extra define so that ventrilo.c uses arc4random() instead of random().

   I'm also in the midst of updating the OpenBSD port for games/qstat so if these changes help, it's be great to see them get merged in.

  Thanks for taking over the qstat repo and continuing to make it available for us old-school gamers!

  -Tom