### PR TITLE
OpenBSD does not have strnstr(), only FreeBSD does.

### DIFF
--- a/utils.h
+++ b/utils.h
@@ -12,7 +12,7 @@
 #endif
 
 // BSD has strnstr
-#if defined(__FreeBSD__) || defined(__MidnightBSD__) || defined(__OpenBSD__)
+#if defined(__FreeBSD__) || defined(__MidnightBSD__)
  #ifndef HAVE_STRNSTR
 		#define HAVE_STRNSTR    1
  #endif         /* HAVE_STRNSTR */


### PR DESCRIPTION
Hi,
  This is just a rework of a previous PR I closed. OpenBSD does not have strnstr(), so I've removed it from utils.h if defined().

  Thanks,
   Tom