### PR TITLE
Many string command updates to help prevent buffer overflows.

### DIFF
--- a/a2s.c
+++ b/a2s.c
@@ -312,7 +312,7 @@ deal_with_a2s_packet(struct qserver *server, char *rawpkt, int pktlen)
 		server->max_players = (unsigned char)pkt[1];
 
 		// version
-		snprintf( buf, sizeof(buf), "%hhu", pkt[2] );
+		snprintf(buf, sizeof(buf), "%hhu", pkt[2]);
 		add_rule(server, "version", buf, 0);
 
 		// dedicated
@@ -373,13 +373,13 @@ deal_with_a2s_packet(struct qserver *server, char *rawpkt, int pktlen)
 			}
 
 			// mod version
-			snprintf( buf, sizeof(buf), "%u", swap_long_from_little(pkt));
+			snprintf(buf, sizeof(buf), "%u", swap_long_from_little(pkt));
 			add_rule(server, "mod_ver", buf, 0);
 			pkt += 4;
 			pktlen -= 4;
 
 			// mod size
-			snprintf( buf, sizeof(buf), "%u", swap_long_from_little(pkt));
+			snprintf(buf, sizeof(buf), "%u", swap_long_from_little(pkt));
 			add_rule(server, "mod_size", buf, 0);
 			pkt += 4;
 			pktlen -= 4;
@@ -405,7 +405,7 @@ deal_with_a2s_packet(struct qserver *server, char *rawpkt, int pktlen)
 		pktlen--;
 
 		// Bots
-		snprintf( buf, sizeof(buf), "%hhu", *pkt );
+		snprintf(buf, sizeof(buf), "%hhu", *pkt);
 		add_rule(server, "bots", buf, 0);
 		pkt++;
 		pktlen--;
@@ -474,7 +474,7 @@ deal_with_a2s_packet(struct qserver *server, char *rawpkt, int pktlen)
 		server->num_players = (unsigned char)pkt[2];
 		server->max_players = (unsigned char)pkt[3];
 		// pkt[4] number of bots
-		snprintf( buf, sizeof(buf), "%hhu", pkt[4] );
+		snprintf(buf, sizeof(buf), "%hhu", pkt[4]);
 		add_rule(server, "bots", buf, 0);
 
 		add_rule(server, "dedicated", pkt[5] ? "1" : "0", 0);
@@ -524,7 +524,7 @@ deal_with_a2s_packet(struct qserver *server, char *rawpkt, int pktlen)
 					goto out_too_short;
 				}
 				gameport = swap_short_from_little(pkt);
-				snprintf( buf, sizeof(buf), "%hu", gameport );
+				snprintf(buf, sizeof(buf), "%hu", gameport);
 				add_rule(server, "game_port", buf, 0);
 				change_server_port(server, gameport, 0);
 				pkt += 2;
@@ -547,7 +547,7 @@ deal_with_a2s_packet(struct qserver *server, char *rawpkt, int pktlen)
 					goto out_too_short;
 				}
 				spectator_port = swap_short_from_little(pkt);
-				snprintf( buf, sizeof(buf), "%hu", spectator_port );
+				snprintf(buf, sizeof(buf), "%hu", spectator_port);
 				add_rule(server, "spectator_port", buf, 0);
 				pkt += 2;
 				pktlen -= 2;

--- a/a2s.c
+++ b/a2s.c
@@ -312,7 +312,7 @@ deal_with_a2s_packet(struct qserver *server, char *rawpkt, int pktlen)
 		server->max_players = (unsigned char)pkt[1];
 
 		// version
-		sprintf(buf, "%hhu", pkt[2]);
+		snprintf( buf, sizeof(buf), "%hhu", pkt[2] );
 		add_rule(server, "version", buf, 0);
 
 		// dedicated
@@ -373,13 +373,13 @@ deal_with_a2s_packet(struct qserver *server, char *rawpkt, int pktlen)
 			}
 
 			// mod version
-			sprintf(buf, "%u", swap_long_from_little(pkt));
+			snprintf( buf, sizeof(buf), "%u", swap_long_from_little(pkt));
 			add_rule(server, "mod_ver", buf, 0);
 			pkt += 4;
 			pktlen -= 4;
 
 			// mod size
-			sprintf(buf, "%u", swap_long_from_little(pkt));
+			snprintf( buf, sizeof(buf), "%u", swap_long_from_little(pkt));
 			add_rule(server, "mod_size", buf, 0);
 			pkt += 4;
 			pktlen -= 4;
@@ -405,7 +405,7 @@ deal_with_a2s_packet(struct qserver *server, char *rawpkt, int pktlen)
 		pktlen--;
 
 		// Bots
-		sprintf(buf, "%hhu", *pkt);
+		snprintf( buf, sizeof(buf), "%hhu", *pkt );
 		add_rule(server, "bots", buf, 0);
 		pkt++;
 		pktlen--;
@@ -474,7 +474,7 @@ deal_with_a2s_packet(struct qserver *server, char *rawpkt, int pktlen)
 		server->num_players = (unsigned char)pkt[2];
 		server->max_players = (unsigned char)pkt[3];
 		// pkt[4] number of bots
-		sprintf(buf, "%hhu", pkt[4]);
+		snprintf( buf, sizeof(buf), "%hhu", pkt[4] );
 		add_rule(server, "bots", buf, 0);
 
 		add_rule(server, "dedicated", pkt[5] ? "1" : "0", 0);
@@ -524,7 +524,7 @@ deal_with_a2s_packet(struct qserver *server, char *rawpkt, int pktlen)
 					goto out_too_short;
 				}
 				gameport = swap_short_from_little(pkt);
-				sprintf(buf, "%hu", gameport);
+				snprintf( buf, sizeof(buf), "%hu", gameport );
 				add_rule(server, "game_port", buf, 0);
 				change_server_port(server, gameport, 0);
 				pkt += 2;
@@ -547,7 +547,7 @@ deal_with_a2s_packet(struct qserver *server, char *rawpkt, int pktlen)
 					goto out_too_short;
 				}
 				spectator_port = swap_short_from_little(pkt);
-				sprintf(buf, "%hu", spectator_port);
+				snprintf( buf, sizeof(buf), "%hu", spectator_port );
 				add_rule(server, "spectator_port", buf, 0);
 				pkt += 2;
 				pktlen -= 2;

--- a/config.c
+++ b/config.c
@@ -200,8 +200,8 @@ qsc_load_default_config_files()
 		}
 		strncpy(path, var, len);
 		path[len] = '\0';
-		strlcat( path, "/", sizeof(path));
-		strlcat( path, HOME_CONFIG_FILE, sizeof(path));
+		strncat( path, "/", sizeof(path) - 1 - strlen(path));
+		strncat( path, HOME_CONFIG_FILE, sizeof(path) - 1 - strlen(path));
 /*	sprintf( path, "%s/%s", var, HOME_CONFIG_FILE); */
 		rc = try_load_config_file(path, 0);
 		if ((rc == 0) || (rc == -1)) {
@@ -457,8 +457,7 @@ pf_top_level(char *text, void *_context)
 	force_upper_case(context->gametype->type_prefix);
 	context->gametype->type_option = (char *)malloc(strlen(game_type) + 2);
 	context->gametype->type_option[0] = '-';
-	strlcpy( &context->gametype->type_option[1], game_type,
-			sizeof(context->gametype->type_option[1]));
+	strcpy(&context->gametype->type_option[1], game_type);
 
 	parse_context = context;
 
@@ -580,8 +579,8 @@ get_config_key(char *first_token, const ConfigKey *keys)
 			REPORT_ERROR((stderr, "Key name too long"));
 			return (-1);
 		}
-		strlcat( key_name, " ", sizeof(key_name));
-		strlcat( key_name, token, sizeof(key_name));
+		strncat( key_name, " ", sizeof(key_name) - 1 - strlen(key_name));
+		strncat( key_name, token, sizeof(key_name) - 1 - strlen(key_name));
 	} while (1);
 
 	if (key == 0) {

--- a/config.c
+++ b/config.c
@@ -200,8 +200,8 @@ qsc_load_default_config_files()
 		}
 		strncpy(path, var, len);
 		path[len] = '\0';
-		strcat(path, "/");
-		strcat(path, HOME_CONFIG_FILE);
+		strlcat( path, "/", sizeof(path));
+		strlcat( path, HOME_CONFIG_FILE, sizeof(path));
 /*	sprintf( path, "%s/%s", var, HOME_CONFIG_FILE); */
 		rc = try_load_config_file(path, 0);
 		if ((rc == 0) || (rc == -1)) {
@@ -210,14 +210,16 @@ qsc_load_default_config_files()
 	}
 
 #ifdef sysconfdir
-		strcpy(path, sysconfdir "/qstat.cfg");
+		strncpy( path, sysconfdir "/qstat.cfg", sizeof(path) -1);
+		path[sizeof(path) -1] = '\0';
 		filename = path;
 #elif defined(_WIN32)
 		if ((filename == NULL) && _pgmptr && strchr(_pgmptr, '\\')) {
 			char *slash = strrchr(_pgmptr, '\\');
 			strncpy(path, _pgmptr, slash - _pgmptr);
 			path[slash - _pgmptr] = '\0';
-			strcat(path, "\\qstat.cfg");
+			strncat( path, "\\qstat.cfg", sizeof(path) -1);
+			path[sizeof(path) -1] = '\0';
 			filename = path;
 		}
 #endif
@@ -455,7 +457,8 @@ pf_top_level(char *text, void *_context)
 	force_upper_case(context->gametype->type_prefix);
 	context->gametype->type_option = (char *)malloc(strlen(game_type) + 2);
 	context->gametype->type_option[0] = '-';
-	strcpy(&context->gametype->type_option[1], game_type);
+	strlcpy( &context->gametype->type_option[1], game_type,
+			sizeof(context->gametype->type_option[1]));
 
 	parse_context = context;
 
@@ -556,7 +559,8 @@ get_config_key(char *first_token, const ConfigKey *keys)
 	char key_name[1024], *token;
 	int key = 0;
 
-	strcpy(key_name, first_token);
+	strncpy( key_name, first_token, sizeof(key_name) -1);
+	key_name[sizeof(key_name) -1] = '\0';
 	do {
 		int k;
 		for (k = 0; keys[k].key_name; k++) {
@@ -576,8 +580,8 @@ get_config_key(char *first_token, const ConfigKey *keys)
 			REPORT_ERROR((stderr, "Key name too long"));
 			return (-1);
 		}
-		strcat(key_name, " ");
-		strcat(key_name, token);
+		strlcat( key_name, " ", sizeof(key_name));
+		strlcat( key_name, token, sizeof(key_name));
 	} while (1);
 
 	if (key == 0) {

--- a/config.c
+++ b/config.c
@@ -117,7 +117,7 @@ static ConfigKey const new_keys[] =
 	{ CK_PLAYER_PACKET,   "player packet"	    },
 	{ CK_RULE_PACKET,     "rule packet"	    },
 	{ CK_PORT_OFFSET,     "status port offset"  },
-	{		   0, NULL		    },
+	{ 0,		      NULL		    },
 };
 
 static ConfigKey const modify_keys[] =
@@ -127,7 +127,7 @@ static ConfigKey const modify_keys[] =
 	{ CK_MASTER_PACKET,   "master packet"	    },
 	{ CK_FLAGS,	      "flags"		    },
 	{ CK_MASTER_TYPE,     "master for gametype" },
-	{		   0, NULL		    },
+	{ 0,		      NULL		    },
 };
 
 typedef struct {
@@ -153,7 +153,7 @@ ServerFlag const server_flags[] =
 	SERVER_FLAG(TF_RAW_STYLE_GHOSTRECON),
 	SERVER_FLAG(TF_NO_PORT_OFFSET),
 	SERVER_FLAG(TF_SHOW_GAME_PORT),
-	{ NULL, 0 }
+	{ NULL,				      0}
 };
 #undef SERVER_FLAG
 
@@ -210,7 +210,7 @@ qsc_load_default_config_files()
 	}
 
 #ifdef sysconfdir
-		strncpy(path, sysconfdir "/qstat.cfg", sizeof(path) -1);
+		strncpy(path, sysconfdir "/qstat.cfg", sizeof(path));
 		path[sizeof(path) -1] = '\0';
 		filename = path;
 #elif defined(_WIN32)
@@ -558,7 +558,7 @@ get_config_key(char *first_token, const ConfigKey *keys)
 	char key_name[1024], *token;
 	int key = 0;
 
-	strncpy(key_name, first_token, sizeof(key_name) -1);
+	strncpy(key_name, first_token, sizeof(key_name));
 	key_name[sizeof(key_name) -1] = '\0';
 	do {
 		int k;

--- a/config.c
+++ b/config.c
@@ -200,8 +200,8 @@ qsc_load_default_config_files()
 		}
 		strncpy(path, var, len);
 		path[len] = '\0';
-		strncat( path, "/", sizeof(path) - 1 - strlen(path));
-		strncat( path, HOME_CONFIG_FILE, sizeof(path) - 1 - strlen(path));
+		strncat(path, "/", sizeof(path) - 1 - strlen(path));
+		strncat(path, HOME_CONFIG_FILE, sizeof(path) - 1 - strlen(path));
 /*	sprintf( path, "%s/%s", var, HOME_CONFIG_FILE); */
 		rc = try_load_config_file(path, 0);
 		if ((rc == 0) || (rc == -1)) {
@@ -210,7 +210,7 @@ qsc_load_default_config_files()
 	}
 
 #ifdef sysconfdir
-		strncpy( path, sysconfdir "/qstat.cfg", sizeof(path) -1);
+		strncpy(path, sysconfdir "/qstat.cfg", sizeof(path) -1);
 		path[sizeof(path) -1] = '\0';
 		filename = path;
 #elif defined(_WIN32)
@@ -218,7 +218,7 @@ qsc_load_default_config_files()
 			char *slash = strrchr(_pgmptr, '\\');
 			strncpy(path, _pgmptr, slash - _pgmptr);
 			path[slash - _pgmptr] = '\0';
-			strncat( path, "\\qstat.cfg", sizeof(path) -1);
+			strncat(path, "\\qstat.cfg", sizeof(path) -1);
 			path[sizeof(path) -1] = '\0';
 			filename = path;
 		}
@@ -558,7 +558,7 @@ get_config_key(char *first_token, const ConfigKey *keys)
 	char key_name[1024], *token;
 	int key = 0;
 
-	strncpy( key_name, first_token, sizeof(key_name) -1);
+	strncpy(key_name, first_token, sizeof(key_name) -1);
 	key_name[sizeof(key_name) -1] = '\0';
 	do {
 		int k;
@@ -579,8 +579,8 @@ get_config_key(char *first_token, const ConfigKey *keys)
 			REPORT_ERROR((stderr, "Key name too long"));
 			return (-1);
 		}
-		strncat( key_name, " ", sizeof(key_name) - 1 - strlen(key_name));
-		strncat( key_name, token, sizeof(key_name) - 1 - strlen(key_name));
+		strncat(key_name, " ", sizeof(key_name) - 1 - strlen(key_name));
+		strncat(key_name, token, sizeof(key_name) - 1 - strlen(key_name));
 	} while (1);
 
 	if (key == 0) {

--- a/crysis.c
+++ b/crysis.c
@@ -46,15 +46,15 @@ send_crysis_request_packet(struct qserver *server)
 	case 0:
 		// Not seen a challenge yet, request it
 		server->challenge++;
-		sprintf(cmd, "challenge");
+		snprintf( cmd, sizeof(cmd), "challenge" );
 		break;
 
 	case 1:
 		server->challenge++;
 		password = get_param_value(server, "password", "");
-		sprintf(cmd, "%s:%s", server->challenge_string, password);
+		snprintf( cmd, sizeof(cmd), "%s:%s", server->challenge_string, password );
 		md5 = md5_hex(cmd, strlen(cmd));
-		sprintf(cmd, "authenticate %s", md5);
+		snprintf( cmd, sizeof(cmd), "authenticate %s", md5 );
 		free(md5);
 		break;
 
@@ -63,7 +63,7 @@ send_crysis_request_packet(struct qserver *server)
 		server->challenge++;
 		server->flags |= TF_STATUS_QUERY;
 		server->n_servers = 3;
-		sprintf(cmd, "status");
+		snprintf( cmd, sizeof(cmd), "status" );
 		break;
 
 	case 3:
@@ -71,7 +71,7 @@ send_crysis_request_packet(struct qserver *server)
 	}
 
 	server->saved_data.pkt_max = -1;
-	sprintf(buf, "POST /RPC2 HTTP/1.1\015\012Keep-Alive: 300\015\012User-Agent: qstat %s\015\012Content-Length: %d\015\012Content-Type: text/xml\015\012\015\012<?xml version=\"1.0\" encoding=\"UTF-8\"?><methodCall><methodName>%s</methodName><params /></methodCall>", VERSION, (int)(98 + strlen(cmd)), cmd);
+	snprintf(buf, sizeof(buf), "POST /RPC2 HTTP/1.1\015\012Keep-Alive: 300\015\012User-Agent: qstat %s\015\012Content-Length: %d\015\012Content-Type: text/xml\015\012\015\012<?xml version=\"1.0\" encoding=\"UTF-8\"?><methodCall><methodName>%s</methodName><params /></methodCall>", VERSION, (int)(98 + strlen(cmd)), cmd);
 
 	return (send_packet(server, buf, strlen(buf)));
 }

--- a/crysis.c
+++ b/crysis.c
@@ -46,15 +46,15 @@ send_crysis_request_packet(struct qserver *server)
 	case 0:
 		// Not seen a challenge yet, request it
 		server->challenge++;
-		snprintf( cmd, sizeof(cmd), "challenge" );
+		snprintf(cmd, sizeof(cmd), "challenge");
 		break;
 
 	case 1:
 		server->challenge++;
 		password = get_param_value(server, "password", "");
-		snprintf( cmd, sizeof(cmd), "%s:%s", server->challenge_string, password );
+		snprintf(cmd, sizeof(cmd), "%s:%s", server->challenge_string, password);
 		md5 = md5_hex(cmd, strlen(cmd));
-		snprintf( cmd, sizeof(cmd), "authenticate %s", md5 );
+		snprintf(cmd, sizeof(cmd), "authenticate %s", md5);
 		free(md5);
 		break;
 
@@ -63,7 +63,7 @@ send_crysis_request_packet(struct qserver *server)
 		server->challenge++;
 		server->flags |= TF_STATUS_QUERY;
 		server->n_servers = 3;
-		snprintf( cmd, sizeof(cmd), "status" );
+		snprintf(cmd, sizeof(cmd), "status");
 		break;
 
 	case 3:

--- a/cube2.c
+++ b/cube2.c
@@ -179,43 +179,43 @@ deal_with_cube2_packet(struct qserver *server, char *rawpkt, int pktlen)
 
 	server->protocol_version = attr[0];
 
-	snprintf( buf, sizeof(buf), "%d %s", attr[0], sb_getversion_s (attr[0]) );
+	snprintf(buf, sizeof(buf), "%d %s", attr[0], sb_getversion_s (attr[0]));
 	add_rule(server, "version", buf, NO_FLAGS);
 
-	snprintf( buf, sizeof(buf), "%d %s", attr[1], sb_getmode_s (attr[1]) );
+	snprintf(buf, sizeof(buf), "%d %s", attr[1], sb_getmode_s (attr[1]));
 	add_rule(server, "mode", buf, NO_FLAGS);
 
-	snprintf( buf, sizeof(buf), "%d", attr[2] );
+	snprintf(buf, sizeof(buf), "%d", attr[2]);
 	add_rule(server, "seconds_left", buf, NO_FLAGS);
 
 	server->max_players = attr[3];
 
 	switch (attr[5]) {
 	case MM_OPEN:
-		snprintf( buf, sizeof(buf), "%d open", attr[5] );
+		snprintf(buf, sizeof(buf), "%d open", attr[5]);
 		break;
 
 	case MM_VETO:
-		snprintf( buf, sizeof(buf), "%d veto", attr[5] );
+		snprintf(buf, sizeof(buf), "%d veto", attr[5]);
 		break;
 
 	case MM_LOCKED:
-		snprintf( buf, sizeof(buf), "%d locked", attr[5] );
+		snprintf(buf, sizeof(buf), "%d locked", attr[5]);
 		break;
 
 	case MM_PRIVATE:
-		snprintf( buf, sizeof(buf), "%d private", attr[5] );
+		snprintf(buf, sizeof(buf), "%d private", attr[5]);
 		break;
 
 	default:
-		snprintf( buf, sizeof(buf), "%d unknown", attr[5] );
+		snprintf(buf, sizeof(buf), "%d unknown", attr[5]);
 	}
 	add_rule(server, "mm", buf, NO_FLAGS);
 
 	for (i = 0; i < numattr && i < MAX_ATTR; i++) {
 		char buf2[MAX_STRING];
-		snprintf( buf, sizeof(buf), "attr%d", i );
-		snprintf( buf2, sizeof(buf2), "%d", attr[i] );
+		snprintf(buf, sizeof(buf), "attr%d", i);
+		snprintf(buf2, sizeof(buf2), "%d", attr[i]);
 		add_rule(server, buf, buf2, NO_FLAGS);
 	}
 

--- a/cube2.c
+++ b/cube2.c
@@ -179,10 +179,10 @@ deal_with_cube2_packet(struct qserver *server, char *rawpkt, int pktlen)
 
 	server->protocol_version = attr[0];
 
-	snprintf(buf, sizeof(buf), "%d %s", attr[0], sb_getversion_s (attr[0]));
+	snprintf(buf, sizeof(buf), "%d %s", attr[0], sb_getversion_s(attr[0]));
 	add_rule(server, "version", buf, NO_FLAGS);
 
-	snprintf(buf, sizeof(buf), "%d %s", attr[1], sb_getmode_s (attr[1]));
+	snprintf(buf, sizeof(buf), "%d %s", attr[1], sb_getmode_s(attr[1]));
 	add_rule(server, "mode", buf, NO_FLAGS);
 
 	snprintf(buf, sizeof(buf), "%d", attr[2]);

--- a/cube2.c
+++ b/cube2.c
@@ -179,43 +179,43 @@ deal_with_cube2_packet(struct qserver *server, char *rawpkt, int pktlen)
 
 	server->protocol_version = attr[0];
 
-	sprintf(buf, "%d %s", attr[0], sb_getversion_s(attr[0]));
+	snprintf( buf, sizeof(buf), "%d %s", attr[0], sb_getversion_s (attr[0]) );
 	add_rule(server, "version", buf, NO_FLAGS);
 
-	sprintf(buf, "%d %s", attr[1], sb_getmode_s(attr[1]));
+	snprintf( buf, sizeof(buf), "%d %s", attr[1], sb_getmode_s (attr[1]) );
 	add_rule(server, "mode", buf, NO_FLAGS);
 
-	sprintf(buf, "%d", attr[2]);
+	snprintf( buf, sizeof(buf), "%d", attr[2] );
 	add_rule(server, "seconds_left", buf, NO_FLAGS);
 
 	server->max_players = attr[3];
 
 	switch (attr[5]) {
 	case MM_OPEN:
-		sprintf(buf, "%d open", attr[5]);
+		snprintf( buf, sizeof(buf), "%d open", attr[5] );
 		break;
 
 	case MM_VETO:
-		sprintf(buf, "%d veto", attr[5]);
+		snprintf( buf, sizeof(buf), "%d veto", attr[5] );
 		break;
 
 	case MM_LOCKED:
-		sprintf(buf, "%d locked", attr[5]);
+		snprintf( buf, sizeof(buf), "%d locked", attr[5] );
 		break;
 
 	case MM_PRIVATE:
-		sprintf(buf, "%d private", attr[5]);
+		snprintf( buf, sizeof(buf), "%d private", attr[5] );
 		break;
 
 	default:
-		sprintf(buf, "%d unknown", attr[5]);
+		snprintf( buf, sizeof(buf), "%d unknown", attr[5] );
 	}
 	add_rule(server, "mm", buf, NO_FLAGS);
 
 	for (i = 0; i < numattr && i < MAX_ATTR; i++) {
 		char buf2[MAX_STRING];
-		sprintf(buf, "attr%d", i);
-		sprintf(buf2, "%d", attr[i]);
+		snprintf( buf, sizeof(buf), "attr%d", i );
+		snprintf( buf2, sizeof(buf2), "%d", attr[i] );
 		add_rule(server, buf, buf2, NO_FLAGS);
 	}
 

--- a/debug.c
+++ b/debug.c
@@ -171,7 +171,7 @@ output_packet(struct qserver *server, const char *buf, int buflen, int to)
 	for (i = buflen; i; offset += 16) {
 		memset(line, ' ', 256);
 		h = 0;
-		h+= snprintf( line, sizeof(line), "%5d:", offset);
+		h+= snprintf(line, sizeof(line), "%5d:", offset);
 		a = astart = h + 16 * 2 + 16 / 4 + 2;
 		for (b = 16; b && i; b--, i--, p++) {
 			if ((b & 3) == 0) {

--- a/debug.c
+++ b/debug.c
@@ -114,7 +114,7 @@ malformed_packet(const struct qserver *server, const char *fmt, ...)
 		char fn[PATH_MAX] = { 0 };
 		int fd;
 
-		sprintf(fn, "%03u_%s.pkt", count++, tag);
+		snprintf(fn, sizeof(fn), "%03u_%s.pkt", count++, tag);
 		fprintf(stderr, "dumping to %s\n", fn);
 		fd = open(fn, O_WRONLY | O_CREAT | O_EXCL, 0644);
 		if (fd == -1) {
@@ -171,7 +171,7 @@ output_packet(struct qserver *server, const char *buf, int buflen, int to)
 	for (i = buflen; i; offset += 16) {
 		memset(line, ' ', 256);
 		h = 0;
-		h += sprintf(line, "%5d:", offset);
+		h+= snprintf( line, sizeof(line), "%5d:", offset);
 		a = astart = h + 16 * 2 + 16 / 4 + 2;
 		for (b = 16; b && i; b--, i--, p++) {
 			if ((b & 3) == 0) {

--- a/debug.c
+++ b/debug.c
@@ -171,7 +171,7 @@ output_packet(struct qserver *server, const char *buf, int buflen, int to)
 	for (i = buflen; i; offset += 16) {
 		memset(line, ' ', 256);
 		h = 0;
-		h+= snprintf(line, sizeof(line), "%5d:", offset);
+		h += snprintf(line, sizeof(line), "%5d:", offset);
 		a = astart = h + 16 * 2 + 16 / 4 + 2;
 		for (b = 16; b && i; b--, i--, p++) {
 			if ((b & 3) == 0) {

--- a/dirtybomb.c
+++ b/dirtybomb.c
@@ -45,7 +45,7 @@ send_dirtybomb_request_packet(struct qserver *server)
 		chunks |= 0x04; // Player
 		chunks |= 0x08; // Team - Currently not supported
 	}
-	sprintf(buf, "%c%c%s%c", 0x01, len, password, chunks);
+	snprintf(buf, sizeof(buf), "%c%c%s%c", 0x01, len, password, chunks);
 
 	server->saved_data.pkt_max = -1;
 

--- a/display_json.c
+++ b/display_json.c
@@ -425,7 +425,7 @@ json_display_tribes2_player_info(struct qserver *server)
 	// Build Teams into a seperate object
 	xform_printf(OF, ",\n\t\t\"teams\": [\n");
 
-	player = server->players;	
+	player = server->players;
 	for ( ; player != NULL; player = player->next) {
 		if (player->number == TRIBES_TEAM) {
 			if (printed) {
@@ -436,7 +436,6 @@ json_display_tribes2_player_info(struct qserver *server)
 			xform_printf(OF, "\t\t\t\t\"team\": \"%s\",\n", json_escape(xform_name(player->name, server)));
 			xform_printf(OF, "\t\t\t\t\"score\": %d\n", player->frags);
 			xform_printf(OF, "\t\t\t}");
-
 		}
 	}
 

--- a/doom3.c
+++ b/doom3.c
@@ -370,7 +370,7 @@ _deal_with_doom3_packet(struct qserver *server, char *rawpkt, int pktlen, unsign
 			server->max_players = atoi(val);
 		} else if (0 == strcasecmp(key, "ri_maxViewers")) {
 			char max[20];
-			snprintf( max, sizeof(max), "%d", server->max_players );
+			snprintf(max, sizeof(max), "%d", server->max_players);
 			add_rule(server, "si_maxplayers", max, NO_FLAGS);
 			server->max_players = atoi(val);
 		} else if (0 == strcasecmp(key, "ri_numViewers")) {

--- a/doom3.c
+++ b/doom3.c
@@ -370,7 +370,7 @@ _deal_with_doom3_packet(struct qserver *server, char *rawpkt, int pktlen, unsign
 			server->max_players = atoi(val);
 		} else if (0 == strcasecmp(key, "ri_maxViewers")) {
 			char max[20];
-			sprintf(max, "%d", server->max_players);
+			snprintf( max, sizeof(max), "%d", server->max_players );
 			add_rule(server, "si_maxplayers", max, NO_FLAGS);
 			server->max_players = atoi(val);
 		} else if (0 == strcasecmp(key, "ri_numViewers")) {

--- a/farmsim.c
+++ b/farmsim.c
@@ -43,7 +43,7 @@ send_farmsim_request_packet(struct qserver *server)
 
 	server->saved_data.pkt_max = -1;
 	code = get_param_value(server, "code", "");
-	sprintf(buf, "GET /feed/dedicated-server-stats.xml?code=%s HTTP/1.1\015\012User-Agent: qstat\015\012\015\012", code);
+	snprintf(buf, sizeof(buf), "GET /feed/dedicated-server-stats.xml?code=%s HTTP/1.1\015\012User-Agent: qstat\015\012\015\012", code);
 
 	return (send_packet(server, buf, strlen(buf)));
 }

--- a/fl.c
+++ b/fl.c
@@ -340,20 +340,20 @@ deal_with_fl_packet(struct qserver *server, char *rawpkt, int pktlen)
 		add_rule(server, "passworded", (*pkt++) ? "1" : "0", 0);
 
 		// FrameTime
-		sprintf(buf, "%hhu", *pkt++);
+		snprintf( buf, sizeof(buf), "%hhu", *pkt++ );
 		add_rule(server, "frametime", buf, 0);
 
 		// Round
-		sprintf(buf, "%hhu", *pkt++);
+		snprintf( buf, sizeof(buf), "%hhu", *pkt++ );
 		add_rule(server, "round", buf, 0);
 
 		// RoundMax
-		sprintf(buf, "%hhu", *pkt++);
+		snprintf( buf, sizeof(buf), "%hhu", *pkt++ );
 		add_rule(server, "roundmax", buf, 0);
 
 		// RoundSeconds
 		tmp_short = ((unsigned short)pkt[0] << 8) | ((unsigned short)pkt[1]);
-		sprintf(buf, "%hu", tmp_short);
+		snprintf( buf, sizeof(buf), "%hhu", tmp_short );
 		add_rule(server, "roundseconds", buf, 0);
 		pkt += 2;
 

--- a/fl.c
+++ b/fl.c
@@ -340,20 +340,20 @@ deal_with_fl_packet(struct qserver *server, char *rawpkt, int pktlen)
 		add_rule(server, "passworded", (*pkt++) ? "1" : "0", 0);
 
 		// FrameTime
-		snprintf( buf, sizeof(buf), "%hhu", *pkt++ );
+		snprintf(buf, sizeof(buf), "%hhu", *pkt++);
 		add_rule(server, "frametime", buf, 0);
 
 		// Round
-		snprintf( buf, sizeof(buf), "%hhu", *pkt++ );
+		snprintf(buf, sizeof(buf), "%hhu", *pkt++);
 		add_rule(server, "round", buf, 0);
 
 		// RoundMax
-		snprintf( buf, sizeof(buf), "%hhu", *pkt++ );
+		snprintf(buf, sizeof(buf), "%hhu", *pkt++);
 		add_rule(server, "roundmax", buf, 0);
 
 		// RoundSeconds
 		tmp_short = ((unsigned short)pkt[0] << 8) | ((unsigned short)pkt[1]);
-		snprintf( buf, sizeof(buf), "%hhu", tmp_short );
+		snprintf(buf, sizeof(buf), "%hhu", tmp_short);
 		add_rule(server, "roundseconds", buf, 0);
 		pkt += 2;
 

--- a/gs3.c
+++ b/gs3.c
@@ -229,8 +229,8 @@ deal_with_gs3_status(struct qserver *server, char *rawpkt, int pktlen)
 						if (server->server_name) {
 							char *name = (char *)realloc(server->server_name, strlen(server->server_name) + strlen(val) + 3);
 							if (name) {
-								strlcat( name, ": ", sizeof(name) );
-								strlcat( name, val, sizeof(name) );
+								strncat( name, ": ", sizeof(name) - 1 - strlen(name) );
+								strncat( name, val, sizeof(name) - 1 - strlen(name) );
 								server->server_name = name;
 							}
 						}
@@ -381,8 +381,8 @@ process_gs3_packet(struct qserver *server)
 									if (server->server_name) {
 										char *name = (char *)realloc(server->server_name, strlen(server->server_name) + strlen(val) + 3);
 										if (name) {
-											strlcat( name, ": ", sizeof(name) );
-											strlcat( name, val, sizeof(name) );
+											strncat( name, ": ", sizeof(name) - 1 - strlen(name) );
+											strncat( name, val, sizeof(name) - 1 - strlen(name) );
 											server->server_name = name;
 										}
 									}

--- a/gs3.c
+++ b/gs3.c
@@ -229,8 +229,8 @@ deal_with_gs3_status(struct qserver *server, char *rawpkt, int pktlen)
 						if (server->server_name) {
 							char *name = (char *)realloc(server->server_name, strlen(server->server_name) + strlen(val) + 3);
 							if (name) {
-								strcat(name, ": ");
-								strcat(name, val);
+								strlcat( name, ": ", sizeof(name) );
+								strlcat( name, val, sizeof(name) );
 								server->server_name = name;
 							}
 						}
@@ -381,8 +381,8 @@ process_gs3_packet(struct qserver *server)
 									if (server->server_name) {
 										char *name = (char *)realloc(server->server_name, strlen(server->server_name) + strlen(val) + 3);
 										if (name) {
-											strcat(name, ": ");
-											strcat(name, val);
+											strlcat( name, ": ", sizeof(name) );
+											strlcat( name, val, sizeof(name) );
 											server->server_name = name;
 										}
 									}
@@ -643,7 +643,7 @@ process_gs3_packet(struct qserver *server)
 				case TEAM_OTHER_HEADER:
 				default:
 					// add as a server rule
-					sprintf(rule, "%s%d", header, total_teams);
+					snprintf( rule, sizeof(rule), "%s%d", header, total_teams );
 					add_rule(server, rule, val, NO_FLAGS);
 					break;
 				}
@@ -675,8 +675,9 @@ send_gs3_request_packet(struct qserver *server)
 		server->flags |= TF_PLAYER_QUERY | TF_RULES_QUERY;
 		if (server->challenge) {
 			// we've recieved a challenge response, send the query + challenge id
-			len = sprintf(
+			len = snprintf(
 				query_buf,
+				sizeof(query_buf),
 				"\xfe\xfd%c\x10\x20\x30\x40%c%c%c%c\xff\xff\xff\x01",
 				0x00,
 				(unsigned char)(server->challenge >> 24),
@@ -694,8 +695,9 @@ send_gs3_request_packet(struct qserver *server)
 		server->flags |= TF_STATUS_QUERY;
 		if (server->challenge) {
 			// we've recieved a challenge response, send the query + challenge id
-			len = sprintf(
+			len = snprintf(
 				query_buf,
+				sizeof(query_buf),
 				"\xfe\xfd%c\x10\x20\x30\x40%c%c%c%c\x06\x01\x06\x05\x08\x0a\x04%c%c",
 				0x00,
 				(unsigned char)(server->challenge >> 24),

--- a/gs3.c
+++ b/gs3.c
@@ -229,8 +229,8 @@ deal_with_gs3_status(struct qserver *server, char *rawpkt, int pktlen)
 						if (server->server_name) {
 							char *name = (char *)realloc(server->server_name, strlen(server->server_name) + strlen(val) + 3);
 							if (name) {
-								strncat( name, ": ", sizeof(name) - 1 - strlen(name) );
-								strncat( name, val, sizeof(name) - 1 - strlen(name) );
+								strncat(name, ": ", sizeof(name) - 1 - strlen(name));
+								strncat(name, val, sizeof(name) - 1 - strlen(name));
 								server->server_name = name;
 							}
 						}
@@ -381,8 +381,8 @@ process_gs3_packet(struct qserver *server)
 									if (server->server_name) {
 										char *name = (char *)realloc(server->server_name, strlen(server->server_name) + strlen(val) + 3);
 										if (name) {
-											strncat( name, ": ", sizeof(name) - 1 - strlen(name) );
-											strncat( name, val, sizeof(name) - 1 - strlen(name) );
+											strncat(name, ": ", sizeof(name) - 1 - strlen(name));
+											strncat(name, val, sizeof(name) - 1 - strlen(name));
 											server->server_name = name;
 										}
 									}
@@ -643,7 +643,7 @@ process_gs3_packet(struct qserver *server)
 				case TEAM_OTHER_HEADER:
 				default:
 					// add as a server rule
-					snprintf( rule, sizeof(rule), "%s%d", header, total_teams );
+					snprintf(rule, sizeof(rule), "%s%d", header, total_teams);
 					add_rule(server, rule, val, NO_FLAGS);
 					break;
 				}

--- a/haze.c
+++ b/haze.c
@@ -491,7 +491,7 @@ process_haze_packet(struct qserver *server)
 				case TEAM_OTHER_HEADER:
 				default:
 					// add as a server rule
-					snprintf( rule, sizeof(rule), "%s%d", header, total_teams );
+					snprintf(rule, sizeof(rule), "%s%d", header, total_teams);
 					add_rule(server, rule, val, NO_FLAGS);
 					break;
 				}

--- a/haze.c
+++ b/haze.c
@@ -491,7 +491,7 @@ process_haze_packet(struct qserver *server)
 				case TEAM_OTHER_HEADER:
 				default:
 					// add as a server rule
-					sprintf(rule, "%s%d", header, total_teams);
+					snprintf( rule, sizeof(rule), "%s%d", header, total_teams );
 					add_rule(server, rule, val, NO_FLAGS);
 					break;
 				}
@@ -533,8 +533,9 @@ send_haze_request_packet(struct qserver *server)
 
 	if (server->challenge) {
 		// we've recieved a challenge response, send the query + challenge id
-		len = sprintf(
+		len = snprintf(
 			query_buf,
+			sizeof(query_buf),
 			"frdquery%c%c%c%c%c",
 			(unsigned char)(server->challenge >> 24),
 			(unsigned char)(server->challenge >> 16),

--- a/mumble.c
+++ b/mumble.c
@@ -43,7 +43,7 @@ deal_with_mumble_packet(struct qserver *server, char *rawpkt, int pktlen)
 
 	// version
 	server->protocol_version = ntohl(*(unsigned long *)pkt);
-	sprintf(version, "%u.%u.%u", (unsigned char)*pkt + 1, (unsigned char)*pkt + 2, (unsigned char)*pkt + 3);
+	snprintf(version,sizeof(version),"%u.%u.%u", (unsigned char)*pkt+1, (unsigned char)*pkt+2, (unsigned char)*pkt+3);
 	add_rule(server, "version", version, NO_FLAGS);
 	pkt += 4;
 
@@ -59,7 +59,7 @@ deal_with_mumble_packet(struct qserver *server, char *rawpkt, int pktlen)
 	pkt += 4;
 
 	// allowed bandwidth
-	sprintf(bandwidth, "%d", ntohl(*(unsigned long *)pkt));
+	snprintf( bandwidth, sizeof(bandwidth), "%d", ntohl(*(unsigned long*)pkt));
 	add_rule(server, "allowed_bandwidth", bandwidth, NO_FLAGS);
 	pkt += 4;
 

--- a/mumble.c
+++ b/mumble.c
@@ -59,7 +59,7 @@ deal_with_mumble_packet(struct qserver *server, char *rawpkt, int pktlen)
 	pkt += 4;
 
 	// allowed bandwidth
-	snprintf( bandwidth, sizeof(bandwidth), "%d", ntohl(*(unsigned long*)pkt));
+	snprintf(bandwidth, sizeof(bandwidth), "%d", ntohl(*(unsigned long*)pkt));
 	add_rule(server, "allowed_bandwidth", bandwidth, NO_FLAGS);
 	pkt += 4;
 

--- a/mumble.c
+++ b/mumble.c
@@ -43,7 +43,7 @@ deal_with_mumble_packet(struct qserver *server, char *rawpkt, int pktlen)
 
 	// version
 	server->protocol_version = ntohl(*(unsigned long *)pkt);
-	snprintf(version,sizeof(version),"%u.%u.%u", (unsigned char)*pkt+1, (unsigned char)*pkt+2, (unsigned char)*pkt+3);
+	snprintf(version, sizeof(version), "%u.%u.%u", (unsigned char)*pkt + 1, (unsigned char)*pkt + 2, (unsigned char)*pkt + 3);
 	add_rule(server, "version", version, NO_FLAGS);
 	pkt += 4;
 
@@ -59,7 +59,7 @@ deal_with_mumble_packet(struct qserver *server, char *rawpkt, int pktlen)
 	pkt += 4;
 
 	// allowed bandwidth
-	snprintf(bandwidth, sizeof(bandwidth), "%d", ntohl(*(unsigned long*)pkt));
+	snprintf(bandwidth, sizeof(bandwidth), "%d", ntohl(*(unsigned long *)pkt));
 	add_rule(server, "allowed_bandwidth", bandwidth, NO_FLAGS);
 	pkt += 4;
 

--- a/qstat.c
+++ b/qstat.c
@@ -11426,7 +11426,7 @@ play_time(int seconds, int show_seconds)
 		if (seconds / 3600) {
 			snprintf(time_string, sizeof(time_string), fmt_hour, seconds / 3600);
 		} else if (show_seconds < 2) {
-			strncat(time_string, "   ", sizeof(time_string) - 1 - strlen(time_string);
+			strncat(time_string, "   ", sizeof(time_string) - 1 - strlen(time_string));
 		}
 		if ((seconds % 3600) / 60 || seconds / 3600) {
 			snprintf(time_string + strlen(time_string),

--- a/qstat.c
+++ b/qstat.c
@@ -305,7 +305,7 @@ standard_display_server(struct qserver *server)
 	char prefix[64];
 
 	if (display_prefix) {
-		sprintf(prefix, "%-4s ", server->type->type_prefix);
+		snprintf(prefix, sizeof(prefix), "%-4s ", server->type->type_prefix);
 	} else {
 		prefix[0] = '\0';
 	}
@@ -395,7 +395,7 @@ standard_display_server(struct qserver *server)
 		}
 	} else {
 		char name[512];
-		sprintf(name, "\"%s\"", server->server_name);
+		snprintf(name, sizeof(name), "\"%s\"", server->server_name);
 		xform_printf(OF,
 		    "%-16s %10s map %s at %22s %d/%d players %d ms\n",
 		    (hostname_lookup) ? server->host_name : server->arg,
@@ -471,17 +471,18 @@ display_q_player_info(struct qserver *server)
 	char fmt[128];
 	struct player *player;
 
-	strcpy(fmt, "\t#%-2d %3d frags %9s ");
+	strncpy(fmt, "\t#%-2d %3d frags %9s ", sizeof(fmt) -1);
+	fmt[sizeof(fmt) -1] = '\0';
 
 	if (color_names) {
-		strcat(fmt, "%9s:%-9s ");
+		strncat(fmt, "%9s:%-9s ", sizeof(fmt) - 1 - strlen(fmt));
 	} else {
-		strcat(fmt, "%2s:%-2s ");
+		strncat(fmt, "%2s:%-2s ", sizeof(fmt) - 1 - strlen(fmt));
 	}
 	if (player_address) {
-		strcat(fmt, "%22s ");
+		strncat(fmt, "%22s ", sizeof(fmt) - 1 - strlen(fmt));
 	} else {
-		strcat(fmt, "%s");
+		strncat(fmt, "%s", sizeof(fmt) - 1 - strlen(fmt));
 	}
 	strcat(fmt, "%s\n");
 
@@ -506,14 +507,15 @@ display_qw_player_info(struct qserver *server)
 	char fmt[128];
 	struct player *player;
 
-	strcpy(fmt, "\t#%-6d %5d frags %6s@%-5s %8s");
+	strncpy(fmt, "\t#%-6d %5d frags %6s@%-5s %8s", sizeof(fmt) - 1);
+	fmt[sizeof(fmt) -1] = '\0';
 
 	if (color_names) {
-		strcat(fmt, "%9s:%-9s ");
+		strncat(fmt, "%9s:%-9s ", sizeof(fmt) - 1 - strlen(fmt));
 	} else {
-		strcat(fmt, "%2s:%-2s ");
+		strncat(fmt, "%2s:%-2s ", sizeof(fmt) - 1 - strlen(fmt));
 	}
-	strcat(fmt, "%12s %s\n");
+	strncat(fmt, "%12s %s\n", sizeof(fmt) - 1 - strlen(fmt));
 
 	player = server->players;
 	for ( ; player != NULL; player = player->next) {
@@ -1181,8 +1183,9 @@ raw_display_qw_player_info(struct qserver *server)
 	char fmt[128];
 	struct player *player;
 
-	strcpy(fmt, "%d" "%s%s" "%s%d" "%s%s" "%s%s" "%s%s");
-	strcat(fmt, "%s%d" "%s%s" "%s%s");
+	strncpy(fmt, "%d""%s%s""%s%d""%s%s""%s%s""%s%s", sizeof(fmt) - 1);
+	fmt[sizeof(fmt) - 1] = '\0';
+	strncat(fmt, "%s%d""%s%s""%s%s", sizeof(fmt) - 1 - strlen(fmt));
 
 	player = server->players;
 	for ( ; player != NULL; player = player->next) {
@@ -2535,7 +2538,7 @@ display_progress()
 	} else {
 		int delta = time_delta(&now, &rate_start);
 		if (delta > 1500) {
-			sprintf(rate, "  %d servers/sec  ", (num_servers_returned + num_servers_timed_out) * 1000 / delta);
+			snprintf(rate, sizeof(rate), "  %d servers/sec  ", (num_servers_returned + num_servers_timed_out) *1000 / delta);
 		} else {
 			rate[0] = '\0';
 		}
@@ -3517,7 +3520,7 @@ main(int argc, char *argv[])
 			default_server_type = find_server_type_string(argv[arg]);
 			if (default_server_type == NULL) {
 				char opt[256], *o = &opt[0];
-				sprintf(opt, "-%s", argv[arg]);
+				snprintf(opt, sizeof(opt), "-%s", argv[arg]);
 				for ( ; *o; o++) {
 					*o = tolower(*o);
 				}
@@ -3576,6 +3579,7 @@ main(int argc, char *argv[])
 				usage("missing argument for -sort\n", argv, NULL);
 			}
 			strncpy(sort_keys, argv[arg], sizeof(sort_keys) - 1);
+			sort_keys[sizeof(sort_keys) - 1] = '\0';
 			pos = strspn(sort_keys, SUPPORTED_SORT_KEYS);
 			if (pos != strlen(sort_keys)) {
 				fprintf(stderr, "Unknown sort key \"%c\", valid keys are \"%s\"\n", sort_keys[pos], SUPPORTED_SORT_KEYS);
@@ -4032,7 +4036,7 @@ add_qserver(char *arg, server_type *type, char *outfilename, char *query_arg)
 		}
 		if (hostname && colon) {
 			server->host_name = (char *)malloc(strlen(hostname) + 5 + 2);
-			sprintf(server->host_name, "%s:%hu", hostname, port);
+			snprintf(server->host_name, sizeof(server->host_name), "%s:%hu", hostname, port);
 		} else {
 			server->host_name = strdup((hostname) ? hostname : arg);
 		}
@@ -4113,7 +4117,7 @@ add_qserver_byaddr(unsigned int ipaddr, unsigned short port, server_type *type, 
 	server = (struct qserver *)calloc(1, sizeof(struct qserver));
 	server->ipaddr = ipaddr;
 	ipaddr = ntohl(ipaddr);
-	sprintf(arg, "%d.%d.%d.%d:%hu", ipaddr >> 24, (ipaddr >> 16) & 0xff, (ipaddr >> 8) & 0xff, ipaddr & 0xff, port);
+	snprintf(arg, sizeof(arg), "%d.%d.%d.%d:%hu", ipaddr >> 24, (ipaddr >> 16) &0xff, (ipaddr >> 8) &0xff, ipaddr &0xff, port);
 	server->arg = strdup(arg);
 
 	if (hostname_lookup) {
@@ -4122,7 +4126,7 @@ add_qserver_byaddr(unsigned int ipaddr, unsigned short port, server_type *type, 
 
 	if (hostname) {
 		server->host_name = (char *)malloc(strlen(hostname) + 6 + 2);
-		sprintf(server->host_name, "%s:%hu", hostname, port);
+		snprintf(server->host_name, sizeof(server->host_name), "%s:%hu", hostname, port);
 	} else {
 		server->host_name = strdup(arg);
 	}
@@ -4478,7 +4482,7 @@ connected_qserver(struct qserver *server, int polling)
 			}
 
 			qserver_sockaddr(server, &addr);
-			sprintf(error, "connect:%s:%u - timeout", inet_ntoa(addr.sin_addr), ntohs(addr.sin_port));
+			snprintf(error, sizeof(error), "connect:%s:%u - timeout", inet_ntoa(addr.sin_addr), ntohs(addr.sin_port));
 			server->server_name = TIMEOUT;
 			server->state = STATE_TIMEOUT;
 			goto connect_error;
@@ -4517,7 +4521,7 @@ connect_error:
 		// Default error case
 		if (0 == strlen(error)) {
 			qserver_sockaddr(server, &addr);
-			sprintf(error, "connect: %s:%u", inet_ntoa(addr.sin_addr), ntohs(addr.sin_port));
+			snprintf(error, sizeof(error), "connect: %s:%u", inet_ntoa(addr.sin_addr), ntohs(addr.sin_port));
 		}
 		server->server_name = SYSERROR;
 		server->state = STATE_SYS_ERROR;
@@ -4635,7 +4639,7 @@ bind_qserver2(struct qserver *server, int wait)
 			} else {
 				if (show_errors) {
 					char error[50];
-					sprintf(error, "connect:%s:%u", inet_ntoa(addr.sin_addr), ntohs(addr.sin_port));
+					snprintf(error, sizeof(error), "connect:%s:%u", inet_ntoa(addr.sin_addr), ntohs(addr.sin_port));
 					perror(error);
 				}
 				server->server_name = SYSERROR;
@@ -5051,19 +5055,19 @@ build_hlmaster_packet(struct qserver *server, int *len)
 
 	gamedir = get_param_value(server, "game", NULL);
 	if (gamedir) {
-		pkt += sprintf(pkt, "\\gamedir\\%s", gamedir);
+		pkt += snprintf(pkt, sizeof(pkt), "\\gamedir\\%s", gamedir);
 	}
 
 	// not valid for steam?
 	map = get_param_value(server, "map", NULL);
 	if (map) {
-		pkt += sprintf(pkt, "\\map\\%s", map);
+		pkt += snprintf(pkt, sizeof(pkt), "\\map\\%s", map);
 	}
 
 	// steam
 	flags = get_param_value(server, "napp", NULL);
 	if (flags) {
-		pkt += sprintf(pkt, "\\napp\\%s", flags);
+		pkt += snprintf( pkt, sizeof(pkt), "\\napp\\%s", flags );
 	}
 
 	// not valid for steam?
@@ -5078,23 +5082,23 @@ build_hlmaster_packet(struct qserver *server, int *len)
 		}
 
 		if (strncmp(r, "notempty", flen) == 0) {
-			pkt += sprintf(pkt, "\\empty\\1");
+			pkt += snprintf(pkt, sizeof(pkt), "\\empty\\1");
 		} else if (strncmp(r, "notfull", flen) == 0) {
-			pkt += sprintf(pkt, "\\full\\1");
+			pkt += snprintf(pkt, sizeof(pkt), "\\full\\1");
 		} else if (strncmp(r, "dedicated", flen) == 0) {
 			if (server->type->flags & TF_MASTER_STEAM) {
-				pkt += sprintf(pkt, "\\type\\d");
+				pkt += snprintf(pkt, sizeof(pkt), "\\type\\d");
 			} else {
-				pkt += sprintf(pkt, "\\dedicated\\1");
+				pkt += snprintf(pkt, sizeof(pkt), "\\dedicated\\1");
 			}
 		} else if (strncmp(r, "linux", flen) == 0) {
-			pkt += sprintf(pkt, "\\linux\\1");
+			pkt += snprintf(pkt, sizeof(pkt), "\\linux\\1");
 		} else if (strncmp(r, "proxy", flen) == 0) {
 			// steam
-			pkt += sprintf(pkt, "\\proxy\\1");
+			pkt += snprintf(pkt, sizeof(pkt), "\\proxy\\1");
 		} else if (strncmp(r, "secure", flen) == 0) {
 			// steam
-			pkt += sprintf(pkt, "\\secure\\1");
+			pkt += snprintf(pkt, sizeof(pkt), "\\secure\\1");
 		}
 		r = sep + 1;
 	}
@@ -5149,7 +5153,8 @@ send_qwmaster_request_packet(struct qserver *server)
 			if (tag_len < 9) {
 				// initial case
 				tag_len = 9;
-				strcpy(server->master_query_tag, "0.0.0.0:0");
+				strncpy(server->master_query_tag, "0.0.0.0:0", sizeof(server->master_query_tag) -1);
+				server->master_query_tag[sizeof(server->master_query_tag) -1] = '\0';
 			}
 
 			// 1 byte packet id
@@ -5178,7 +5183,8 @@ send_qwmaster_request_packet(struct qserver *server)
 			if (master_protocol == NULL) {
 				master_protocol = server->type->master_protocol;
 			}
-			packet_len = sprintf(query_buf, server->type->master_packet,
+			packet_len = snprintf(query_buf, sizeof(query_buf),
+				server->type->master_packet,
 				master_protocol ? master_protocol : "",
 				server->type->master_query  ? server->type->master_query : ""
 				);
@@ -5499,7 +5505,8 @@ send_gamespy_master_request(struct qserver *server)
 		return (send_error(server, rc));
 	}
 
-	strcpy(request, server->type->status_packet);
+	strncpy(request, server->type->status_packet, sizeof(request) -1);
+	request[sizeof(request) -1] = '\0';
 
 	for (i = 0; gamespy_query_map[i].qstat_type; i++) {
 		if (strcasecmp(server->query_arg, gamespy_query_map[i].qstat_type) == 0) {
@@ -5508,11 +5515,11 @@ send_gamespy_master_request(struct qserver *server)
 	}
 
 	if (gamespy_query_map[i].gamespy_type == NULL) {
-		strcat(request, server->query_arg);
+		strncat(request, server->query_arg, sizeof(request) - 1 - strlen(request));
 	} else {
-		strcat(request, gamespy_query_map[i].gamespy_type);
+		strncat(request, gamespy_query_map[i].gamespy_type, sizeof(request) - 1 - strlen(request));
 	}
-	strcat(request, "\\final\\");
+	strncat(request, "\\final\\", sizeof(request) - 1 - strlen(request));
 	assert(strlen(request) < sizeof(request));
 
 	rc = send(server->fd, request, strlen(request), 0);
@@ -5550,7 +5557,7 @@ send_rule_request_packet(struct qserver *server)
 	}
 
 	if (server->type->id == Q_SERVER) {
-		strcpy((char *)q_rule.data, server->next_rule);
+		strlcpy((char*)q_rule.data, server->next_rule, sizeof(q_rule.data));
 		len = Q_HEADER_LEN + strlen((char *)q_rule.data) + 1;
 		q_rule.length = htons((short)len);
 	} else {
@@ -6310,7 +6317,8 @@ deal_with_q1qw_packet(struct qserver *server, char *rawpkt, int pktlen)
 					strncpy(server->error, pkt, nl - pkt);
 					server->error[nl - pkt] = '\0';
 				} else {
-					strcpy(server->error, pkt);
+					strncpy(server->error, pkt, sizeof(server->error) -1);
+					server->error[sizeof(server->error) -1] = '\0';
 				}
 				server->server_name = SERVERERROR;
 				complete = 1;
@@ -6537,8 +6545,10 @@ player_info:            debug(3, "player info");
 				nl = strchr(pkt, '\n');
 				if (nl != NULL) {
 					strncpy(server->error, pkt, nl - pkt);
+					server->error[sizeof(server->error) -1] = '\0';
 				} else {
-					strcpy(server->error, pkt);
+					strncpy(server->error, pkt, sizeof(server->error) -1);
+					server->error[sizeof(server->error) -1] = '\0';
 				}
 				server->server_name = SERVERERROR;
 				complete = 1;
@@ -6732,7 +6742,8 @@ deal_with_qwmaster_packet(struct qserver *server, char *rawpkt, int pktlen)
 		unsigned short port = htons(*((unsigned short *)(rawpkt + pktlen - 2)));
 
 		//fprintf( stderr, "NEXT IP=%s:%u\n", ip, port );
-		sprintf(server->master_query_tag, "%s:%u", ip, port);
+		snprintf(server->master_query_tag, sizeof(server->master_query_tag),
+			"%s:%u", ip, port);
 
 		// skip over the 2 byte id
 		rawpkt += 2;
@@ -7316,7 +7327,8 @@ player_add_info(struct player *player, char *key, char *value, int flags)
 					fprintf(stderr, "Failed to malloc combined value\n");
 					exit(1);
 				}
-				sprintf(full_value, "%s%s%s", info->value, multi_delimiter, value);
+				snprintf(full_value, sizeof(full_value), "%s%s%s",
+					info->value, multi_delimiter, value);
 
 				// We should be able to free this
 				free(info->value);
@@ -7390,7 +7402,8 @@ add_rule(struct qserver *server, char *key, char *value, int flags)
 					fprintf(stderr, "Failed to malloc combined value\n");
 					exit(1);
 				}
-				sprintf(full_value, "%s%s%s", rule->value, multi_delimiter, value);
+				snprintf(full_value, sizeof(full_value), "%s%s%s",
+					rule->value, multi_delimiter, value);
 
 				// We should be able to free this
 				free(rule->value);
@@ -7497,7 +7510,8 @@ change_server_port(struct qserver *server, unsigned short port, int force)
 		unsigned int ipaddr = ntohl(server->ipaddr);
 
 		// Update the servers hostname as required
-		sprintf(arg, "%d.%d.%d.%d:%hu", ipaddr >> 24, (ipaddr >> 16) & 0xff, (ipaddr >> 8) & 0xff, ipaddr & 0xff, port);
+		snprintf(arg, sizeof(arg), "%d.%d.%d.%d:%hu",
+			ipaddr >> 24, (ipaddr >> 16) &0xff, (ipaddr >> 8) &0xff, ipaddr &0xff, port);
 
 		if (show_game_port || force || server->flags & TF_SHOW_GAME_PORT) {
 			// Update the server arg
@@ -7505,7 +7519,7 @@ change_server_port(struct qserver *server, unsigned short port, int force)
 			server->arg = strdup(arg);
 
 			// Add a rule noting the previous query port
-			sprintf(arg, "%hu", server->port);
+			snprintf(arg, sizeof(arg), "%hu", server->port);
 			add_rule(server, "_queryport", arg, NO_FLAGS);
 
 			// Update the servers port
@@ -7523,14 +7537,15 @@ change_server_port(struct qserver *server, unsigned short port, int force)
 				if (colon) {
 					*colon = '\0';
 				}
-				sprintf(hostname, "%s:%hu", server->host_name, port);
+				snprintf(hostname, sizeof(hostname), "%s:%hu",
+					server->host_name, port);
 				free(server->host_name);
 				server->host_name = hostname;
 			}
 		}
 
 		// Add a rule noting the servers hostport
-		sprintf(arg, "%hu", port);
+		snprintf(arg, sizeof(arg), "%hu", port);
 		add_rule(server, "hostport", arg, OVERWITE_DUPLICATES);
 	}
 }
@@ -8237,7 +8252,7 @@ deal_with_halflife_packet(struct qserver *server, char *rawpkt, int pktlen)
 		pkt += 2;
 		if (pkt < end) {
 			int protocol = *((unsigned char *)pkt);
-			sprintf(number, "%d", protocol);
+			snprintf(number, sizeof(number), "%d", protocol);
 			add_rule(server, "protocol", number, NO_FLAGS);
 			pkt++;
 		}
@@ -8279,11 +8294,11 @@ deal_with_halflife_packet(struct qserver *server, char *rawpkt, int pktlen)
 				}
 				pkt += strlen(pkt) + 1;
 				n = swap_long_from_little(pkt);
-				sprintf(number, "%d", n);
+				snprintf(number, sizeof(number), "%d", n);
 				add_rule(server, "modversion", number, NO_FLAGS);
 				pkt += 4;
 				n = swap_long_from_little(pkt);
-				sprintf(number, "%d", n);
+				snprintf(number, sizeof(number), "%d", n);
 				add_rule(server, "modsize", number, NO_FLAGS);
 				pkt += 4;
 				add_rule(server, "svonly", *pkt ? "1" : "0", NO_FLAGS);
@@ -8425,7 +8440,8 @@ deal_with_tribes_packet(struct qserver *server, char *rawpkt, int pktlen)
 	server->num_players = *pkt++;
 	server->max_players = *pkt++;
 
-	sprintf(buf, "%u", (unsigned int)pkt[0] + (unsigned int)pkt[1] * 256);
+	snprintf(buf, sizeof(buf), "%u",
+		(unsigned int)pkt[0] + (unsigned int)pkt[1] *256);
 	add_rule(server, "cpu", buf, NO_FLAGS);
 	pkt++;          /* cpu speed, lsb */
 	pkt++;          /* cpu speed, msb */
@@ -8450,7 +8466,7 @@ deal_with_tribes_packet(struct qserver *server, char *rawpkt, int pktlen)
 	if (n_teams == 255) {
 		return (PKT_ERROR);
 	}
-	sprintf(buf, "%d", n_teams);
+	snprintf(buf, sizeof(buf), "%d", n_teams);
 	add_rule(server, "numteams", buf, NO_FLAGS);
 
 	len = *pkt;     /* first title */
@@ -8629,16 +8645,16 @@ deal_with_tribes2_packet(struct qserver *server, char *pkt, int pktlen)
 
 		if (query_version == 5) {
 			net_protocol = swap_long_from_little(pkt);
-			sprintf(str, "%u", net_protocol);
+			snprintf(str, sizeof(str), "%u", net_protocol);
 			add_rule(server, "net_protocol", str, NO_FLAGS);
 			pkt += 4;
 		}
 		minimum_net_protocol = swap_long_from_little(pkt);
-		sprintf(str, "%u", minimum_net_protocol);
+		snprintf(str, sizeof(str), "%u", minimum_net_protocol);
 		add_rule(server, "minimum_net_protocol", str, NO_FLAGS);
 		pkt += 4;
 		build_version = swap_long_from_little(pkt);
-		sprintf(str, "%u", build_version);
+		snprintf(str, sizeof(str), "%u", build_version);
 		add_rule(server, "build_version", str, NO_FLAGS);
 		pkt += 4;
 
@@ -8667,7 +8683,7 @@ deal_with_tribes2_packet(struct qserver *server, char *pkt, int pktlen)
 	pkt += *pkt + 1;
 
 	status = *(unsigned char *)pkt;
-	sprintf(str, "%u", status);
+	snprintf(str, sizeof(str), "%u", status);
 	add_rule(server, "status", str, NO_FLAGS);
 	if (status & TRIBES2_STATUS_DEDICATED) {
 		add_rule(server, "dedicated", "1", NO_FLAGS);
@@ -8701,11 +8717,11 @@ deal_with_tribes2_packet(struct qserver *server, char *pkt, int pktlen)
 	pkt++;
 	server->max_players = *(unsigned char *)pkt;
 	pkt++;
-	sprintf(str, "%u", *(unsigned char *)pkt);
+	snprintf(str, sizeof(str), "%u", *(unsigned char*)pkt);
 	add_rule(server, "bot_count", str, NO_FLAGS);
 	pkt++;
 	cpu_speed = swap_short_from_little(pkt);
-	sprintf(str, "%hu", cpu_speed);
+	snprintf(str, sizeof(str), "%hu", cpu_speed);
 	add_rule(server, "cpu_speed", str, NO_FLAGS);
 	pkt += 2;
 
@@ -8734,7 +8750,7 @@ deal_with_tribes2_packet(struct qserver *server, char *pkt, int pktlen)
 	}
 	*term = '\0';
 	n_teams = atoi(pkt);
-	sprintf(str, "%d", n_teams);
+	snprintf(str, sizeof(str), "%d", n_teams);
 	add_rule(server, "numteams", str, NO_FLAGS);
 	pkt = term + 1;
 
@@ -8941,17 +8957,20 @@ deal_with_ghostrecon_packet(struct qserver *server, char *pkt, int pktlen)
 
 	switch (ServerVersion) {
 	case VERSION_1_2_10:
-		strcpy(str, "1.2.10");
+		strncpy(str, "1.2.10", sizeof(str) -1);
+		str[sizeof(str) - 1] = '\0';
 		pkt += sizeof(Dat2Reply1_2_10);
 		break;
 
 	case VERSION_1_3:
-		strcpy(str, "1.3");
+		strncpy(str, "1.3", sizeof(str) -1);
+		str[sizeof(str) - 1] = '\0';
 		pkt += sizeof(Dat2Reply1_3);
 		break;
 
 	case VERSION_1_4:
-		strcpy(str, "1.4");
+		strncpy(str, "1.4", sizeof(str) -1);
+		str[sizeof(str) - 1] = '\0';
 		pkt += sizeof(Dat2Reply1_4);
 		break;
 	}
@@ -9080,6 +9099,7 @@ deal_with_ghostrecon_packet(struct qserver *server, char *pkt, int pktlen)
 		return (PKT_ERROR);
 	}
 	strncpy(str, pkt, iLen);
+	str[sizeof(str) - 1] = '\0';
 	add_rule(server, "version", str, NO_FLAGS);
 	pkt += iLen;/* version */
 
@@ -9119,19 +9139,23 @@ deal_with_ghostrecon_packet(struct qserver *server, char *pkt, int pktlen)
 
 	switch (pkt[0]) {
 	case 3:
-		strcpy(str, "Joining");
+		strncpy(str, "Joining", sizeof(str) -1);
+		str[sizeof(str) -1] = '\0';
 		break;
 
 	case 4:
-		strcpy(str, "Playing");
+		strncpy(str, "Playing", sizeof(str) -1);
+		str[sizeof(str) -1] = '\0';
 		break;
 
 	case 5:
-		strcpy(str, "Debrief");
+		strncpy(str, "Debrief", sizeof(str) -1);
+		str[sizeof(str) -1] = '\0';
 		break;
 
 	default:
-		strcpy(str, "Undefined");
+		strncpy(str, "Undefined", sizeof(str) -1);
+		str[sizeof(str) -1] = '\0';
 	}
 	add_rule(server, "status", str, NO_FLAGS);
 
@@ -9141,19 +9165,22 @@ deal_with_ghostrecon_packet(struct qserver *server, char *pkt, int pktlen)
 
 	switch (pkt[0]) {
 	case 2:
-		strcpy(str, "COOP");
+		strncpy(str, "COOP", sizeof(str) -1);
+		str[sizeof(str) -1] = '\0';
 		break;
 
 	case 3:
-		strcpy(str, "SOLO");
+		strncpy(str, "SOLO", sizeof(str) -1);
+		str[sizeof(str) -1] = '\0';
 		break;
 
 	case 4:
-		strcpy(str, "TEAM");
+		strncpy(str, "TEAM", sizeof(str) -1);
+		str[sizeof(str) -1] = '\0';
 		break;
 
 	default:
-		sprintf(str, "UNKOWN %u", pkt[0]);
+		snprintf(str, sizeof(str), "UNKOWN %u", pkt[0]);
 		break;
 	}
 
@@ -9186,23 +9213,28 @@ deal_with_ghostrecon_packet(struct qserver *server, char *pkt, int pktlen)
 
 	switch (iSpawnType) {
 	case 0:
-		strcpy(str, "None");
+		strncpy(str, "None", sizeof(str) -1);
+		str[sizeof(str) -1] = '\0';
 		break;
 
 	case 1:
-		strcpy(str, "Individual");
+		strncpy(str, "Individual", sizeof(str) -1);
+		str[sizeof(str) -1] = '\0';
 		break;
 
 	case 2:
-		strcpy(str, "Team");
+		strncpy(str, "Team", sizeof(str) -1);
+		str[sizeof(str) -1] = '\0';
 		break;
 
 	case 3:
-		strcpy(str, "Infinite");
+		strncpy(str, "Infinite", sizeof(str) -1);
+		str[sizeof(str) -1] = '\0';
 		break;
 
 	default:
-		strcpy(str, "Unknown");
+		strncpy(str, "Unknown", sizeof(str) -1);
+		str[sizeof(str) -1] = '\0';
 	}
 
 	add_rule(server, "spawntype", str, NO_FLAGS);
@@ -9325,10 +9357,10 @@ deal_with_ghostrecon_packet(struct qserver *server, char *pkt, int pktlen)
 
 	if ((iSpawnType == 1) || (iSpawnType == 2)) {
 		/* Individual or team */
-		sprintf(str, "%u", iTemp);
+		snprintf(str, sizeof(str), "%u", iTemp);
 	} else {
 		/* else not used */
-		sprintf(str, "%u", 0);
+		snprintf(str, sizeof(str), "%u", 0);
 	}
 	add_rule(server, "spawncount", str, NO_FLAGS);
 	pkt += 1;       // 5
@@ -9337,10 +9369,12 @@ deal_with_ghostrecon_packet(struct qserver *server, char *pkt, int pktlen)
 
 	iTemp = pkt[0]; // Allow Observers
 	if (iTemp) {
-		strcpy(str, "Yes");
+		strncpy(str, "Yes", sizeof(str) -1);
+		str[sizeof(str) -1] = '\0';
 	} else {
 		/* else not used */
-		strcpy(str, "No");
+		strncpy(str, "No", sizeof(str) -1);
+		str[sizeof(str) -1] = '\0';
 	}
 	add_rule(server, "allowobservers", str, NO_FLAGS);
 	pkt += 1;       // 10
@@ -9360,19 +9394,23 @@ deal_with_ghostrecon_packet(struct qserver *server, char *pkt, int pktlen)
 	iTemp = pkt[0]; // IFF
 	switch (iTemp) {
 	case 0:
-		strcpy(str, "None");
+		strncpy(str, "None", sizeof(str) -1);
+		str[sizeof(str) -1] = '\0';
 		break;
 
 	case 1:
-		strcpy(str, "Reticule");
+		strncpy(str, "Reticule", sizeof(str) -1);
+		str[sizeof(str) -1] = '\0';
 		break;
 
 	case 2:
-		strcpy(str, "Names");
+		strncpy(str, "Names", sizeof(str) -1);
+		str[sizeof(str) -1] = '\0';
 		break;
 
 	default:
-		strcpy(str, "Unknown");
+		strncpy(str, "Unknown", sizeof(str) -1);
+		str[sizeof(str) -1] = '\0';
 		break;
 	}
 	add_rule(server, "iff", str, NO_FLAGS);
@@ -10101,11 +10139,11 @@ deal_with_bfris_packet(struct qserver *server, char *rawpkt, int pktlen)
 			char buf[24];
 
 			/* server revision */
-			sprintf(buf, "%d", (unsigned int)saved_data[11]);
+			snprintf(buf, sizeof(buf), "%d", (unsigned int)saved_data[11]);
 			add_rule(server, "Revision", buf, NO_FLAGS);
 
 			/* latency */
-			sprintf(buf, "%d", (unsigned int)saved_data[10]);
+			snprintf(buf, sizeof(buf), "%d", (unsigned int)saved_data[10]);
 			add_rule(server, "Latency", buf, NO_FLAGS);
 
 			/* player allocation */
@@ -10224,7 +10262,7 @@ add_uchar_rule(struct qserver *server, char *key, unsigned char value)
 {
 	char buf[24];
 
-	sprintf(buf, "%u", (unsigned)value);
+	snprintf(buf, sizeof(buf), "%u", (unsigned)value);
 	return (add_rule(server, key, buf, NO_FLAGS));
 }
 
@@ -10263,7 +10301,7 @@ deal_with_descent3_packet(struct qserver *server, char *rawpkt, int pktlen)
 		add_rule(server, "gametype", pkt, NO_FLAGS);
 		pkt += strlen(pkt) + 1;
 
-		sprintf(buf, "%hu", swap_short_from_little(pkt));
+		snprintf(buf, sizeof(buf), "%hu", swap_short_from_little(pkt));
 		add_rule(server, "level_num", buf, NO_FLAGS);
 		pkt += 2;
 		server->num_players = swap_short_from_little(pkt);
@@ -10290,10 +10328,11 @@ deal_with_descent3_packet(struct qserver *server, char *rawpkt, int pktlen)
 		/* bright player ships */
 		add_uchar_rule(server, "mouselook", (unsigned char)((pkt[6] & 1) > 0)); /*
 		                                                                         *                                                                         mouselook enabled */
-		sprintf(buf, "%s%s", (pkt[4] & 16) ? "PP" : "CS", (pkt[6] & 1) ? "-ML" : "");
+		snprintf(buf, sizeof(buf), "%s%s",
+			(pkt[4] &16) ? "PP" : "CS", (pkt[6] &1) ? "-ML" : "");
 		add_rule(server, "servertype", buf, NO_FLAGS);
 
-		sprintf(buf, "%hhu", pkt[9]);
+		snprintf(buf, sizeof(buf), "%hhu", pkt[9]);
 		add_rule(server, "difficulty", buf, NO_FLAGS);
 
 		/* unknown/undecoded fields after known flags removed */
@@ -10629,7 +10668,7 @@ deal_with_hl2_packet(struct qserver *server, char *rawpkt, int pktlen)
 		 */
 
 		server->protocol_version = protocolver;
-		sprintf(temp, "%d", protocolver);
+		snprintf(temp, sizeof(temp), "%d", protocolver);
 		add_rule(server, "protocol", temp, NO_FLAGS);
 
 		// server name
@@ -10661,7 +10700,7 @@ deal_with_hl2_packet(struct qserver *server, char *rawpkt, int pktlen)
 		ptr++;
 
 		// bot players
-		sprintf(temp, "%hhu", (*ptr));
+		snprintf(temp, sizeof(temp), "%hhu", (*ptr));
 		add_rule(server, "bot_players", temp, NO_FLAGS);
 		ptr++;
 
@@ -11075,7 +11114,7 @@ xml_escape(char *string)
 				if (isprint(c)) {
 					*b++ = c;
 				} else {
-					b += sprintf((char *)b, "&#%u;", c);
+					b += snprintf( (char *)b, sizeof(b), "&#%u;", c);
 				}
 			}
 		} else if (xml_encoding == ENCODING_UTF_8) {
@@ -11218,7 +11257,7 @@ strherror(int h_err)
 		return ("no address");
 
 	default:
-		sprintf(msg, "%d", h_err);
+		snprintf(msg, sizeof(msg), "%d", h_err);
 		return (msg);
 	}
 }
@@ -11384,28 +11423,34 @@ play_time(int seconds, int show_seconds)
 		char *fmt_second = show_seconds == 2 ? FMT_SECOND_2 : FMT_SECOND_1;
 		time_string[0] = '\0';
 		if (seconds / 3600) {
-			sprintf(time_string, fmt_hour, seconds / 3600);
+			snprintf(time_string, sizeof(time_string), fmt_hour, seconds / 3600);
 		} else if (show_seconds < 2) {
-			strcat(time_string, "   ");
+			strlcat(time_string, "   ", sizeof(time_string));
 		}
 		if ((seconds % 3600) / 60 || seconds / 3600) {
-			sprintf(time_string + strlen(time_string), fmt_minute, (seconds % 3600) / 60);
+			snprintf(time_string + strlen(time_string),
+				sizeof(time_string) - strlen(time_string),
+				fmt_minute, (seconds % 3600) / 60);
 		} else if (!show_seconds) {
-			sprintf(time_string + strlen(time_string), " 0m");
+			snprintf(time_string + strlen(time_string),
+				sizeof(time_string) - strlen(time_string),
+				" 0m");	
 		} else if (show_seconds < 2) {
-			strcat(time_string, "   ");
+			strlcat(time_string, "   ", sizeof(time_string));
 		}
 		if (show_seconds) {
 			sprintf(time_string + strlen(time_string), fmt_second, seconds % 60);
 		}
 	} else if (time_format == STOPWATCH_TIME) {
 		if (show_seconds) {
-			sprintf(time_string, "%02d:%02d:%02d", seconds / 3600, (seconds % 3600) / 60, seconds % 60);
+			snprintf(time_string, sizeof(time_string),
+				"%02d:%02d:%02d", seconds / 3600, (seconds % 3600) / 60, seconds % 60);
 		} else {
-			sprintf(time_string, "%02d:%02d", seconds / 3600, (seconds % 3600) / 60);
+			snprintf(time_string, sizeof(time_string),
+				"%02d:%02d", seconds / 3600, (seconds % 3600) / 60);
 		}
 	} else {
-		sprintf(time_string, "%d", seconds);
+		snprintf(time_string, sizeof(time_string), "%d", seconds);
 	}
 
 	return (time_string);
@@ -11418,11 +11463,11 @@ ping_time(int ms)
 	static char time_string[24];
 
 	if (ms < 1000) {
-		sprintf(time_string, "%dms", ms);
+		snprintf(time_string, sizeof(time_string), "%dms", ms);
 	} else if (ms < 1000000) {
-		sprintf(time_string, "%ds", ms / 1000);
+		snprintf(time_string, sizeof(time_string), "%ds", ms / 1000);
 	} else {
-		sprintf(time_string, "%dm", ms / 1000 / 60);
+		snprintf(time_string, sizeof(time_string), "%dm", ms / 1000 / 60);
 	}
 	return (time_string);
 }

--- a/qstat.c
+++ b/qstat.c
@@ -484,7 +484,7 @@ display_q_player_info(struct qserver *server)
 	} else {
 		strncat(fmt, "%s", sizeof(fmt) - 1 - strlen(fmt));
 	}
-	strcat(fmt, "%s\n");
+	strncat(fmt, "%s\n", sizeof(fmt) - 1 - strlen(fmt));
 
 	player = server->players;
 	for ( ; player != NULL; player = player->next) {
@@ -5557,7 +5557,8 @@ send_rule_request_packet(struct qserver *server)
 	}
 
 	if (server->type->id == Q_SERVER) {
-		strlcpy((char*)q_rule.data, server->next_rule, sizeof(q_rule.data));
+		strncpy((char*)q_rule.data, server->next_rule, sizeof(q_rule.data) -1);
+		q_rule.data[sizeof(q_rule.data) - 1] = '\0';
 		len = Q_HEADER_LEN + strlen((char *)q_rule.data) + 1;
 		q_rule.length = htons((short)len);
 	} else {

--- a/qstat.c
+++ b/qstat.c
@@ -11426,7 +11426,7 @@ play_time(int seconds, int show_seconds)
 		if (seconds / 3600) {
 			snprintf(time_string, sizeof(time_string), fmt_hour, seconds / 3600);
 		} else if (show_seconds < 2) {
-			strlcat(time_string, "   ", sizeof(time_string));
+			strncat(time_string, "   ", sizeof(time_string) - 1 - strlen(time_string);
 		}
 		if ((seconds % 3600) / 60 || seconds / 3600) {
 			snprintf(time_string + strlen(time_string),
@@ -11437,7 +11437,7 @@ play_time(int seconds, int show_seconds)
 				sizeof(time_string) - strlen(time_string),
 				" 0m");	
 		} else if (show_seconds < 2) {
-			strlcat(time_string, "   ", sizeof(time_string));
+			strncat(time_string, "   ", sizeof(time_string) - 1 - strlen(time_string));
 		}
 		if (show_seconds) {
 			sprintf(time_string + strlen(time_string), fmt_second, seconds % 60);

--- a/qstat.c
+++ b/qstat.c
@@ -5067,7 +5067,7 @@ build_hlmaster_packet(struct qserver *server, int *len)
 	// steam
 	flags = get_param_value(server, "napp", NULL);
 	if (flags) {
-		pkt += snprintf( pkt, sizeof(pkt), "\\napp\\%s", flags );
+		pkt += snprintf(pkt, sizeof(pkt), "\\napp\\%s", flags);
 	}
 
 	// not valid for steam?
@@ -11115,7 +11115,7 @@ xml_escape(char *string)
 				if (isprint(c)) {
 					*b++ = c;
 				} else {
-					b += snprintf( (char *)b, sizeof(b), "&#%u;", c);
+					b += snprintf((char *)b, sizeof(b), "&#%u;", c);
 				}
 			}
 		} else if (xml_encoding == ENCODING_UTF_8) {

--- a/qstat.c
+++ b/qstat.c
@@ -471,7 +471,7 @@ display_q_player_info(struct qserver *server)
 	char fmt[128];
 	struct player *player;
 
-	strncpy(fmt, "\t#%-2d %3d frags %9s ", sizeof(fmt) -1);
+	strncpy(fmt, "\t#%-2d %3d frags %9s ", sizeof(fmt));
 	fmt[sizeof(fmt) -1] = '\0';
 
 	if (color_names) {
@@ -507,7 +507,7 @@ display_qw_player_info(struct qserver *server)
 	char fmt[128];
 	struct player *player;
 
-	strncpy(fmt, "\t#%-6d %5d frags %6s@%-5s %8s", sizeof(fmt) - 1);
+	strncpy(fmt, "\t#%-6d %5d frags %6s@%-5s %8s", sizeof(fmt));
 	fmt[sizeof(fmt) -1] = '\0';
 
 	if (color_names) {
@@ -1183,9 +1183,9 @@ raw_display_qw_player_info(struct qserver *server)
 	char fmt[128];
 	struct player *player;
 
-	strncpy(fmt, "%d""%s%s""%s%d""%s%s""%s%s""%s%s", sizeof(fmt) - 1);
+	strncpy(fmt, "%d" "%s%s" "%s%d" "%s%s" "%s%s" "%s%s", sizeof(fmt));
 	fmt[sizeof(fmt) - 1] = '\0';
-	strncat(fmt, "%s%d""%s%s""%s%s", sizeof(fmt) - 1 - strlen(fmt));
+	strncat(fmt, "%s%d" "%s%s" "%s%s", sizeof(fmt) - 1 - strlen(fmt));
 
 	player = server->players;
 	for ( ; player != NULL; player = player->next) {
@@ -3578,7 +3578,7 @@ main(int argc, char *argv[])
 			if (arg >= argc) {
 				usage("missing argument for -sort\n", argv, NULL);
 			}
-			strncpy(sort_keys, argv[arg], sizeof(sort_keys) - 1);
+			strncpy(sort_keys, argv[arg], sizeof(sort_keys));
 			sort_keys[sizeof(sort_keys) - 1] = '\0';
 			pos = strspn(sort_keys, SUPPORTED_SORT_KEYS);
 			if (pos != strlen(sort_keys)) {
@@ -4685,7 +4685,7 @@ bind_sockets()
 
 	first_server = server;
 
-	for ( ; server != NULL && connected < max_simultaneous; ) {
+	for ( ; server != NULL && connected < max_simultaneous;) {
 		// note the next server for use as process_func can free the server
 		next_server = server->next;
 		if ((server->server_name == NULL) && (server->fd == -1)) {
@@ -4736,7 +4736,7 @@ bind_sockets()
 	while (inprogress) {
 		inprogress = 0;
 		server = first_server;
-		for ( ; server != last_server; ) {
+		for ( ; server != last_server;) {
 			next_server = server->next;
 			if (STATE_CONNECTING == server->state) {
 				rc = connected_qserver(server, 1);
@@ -5153,7 +5153,7 @@ send_qwmaster_request_packet(struct qserver *server)
 			if (tag_len < 9) {
 				// initial case
 				tag_len = 9;
-				strncpy(server->master_query_tag, "0.0.0.0:0", sizeof(server->master_query_tag) -1);
+				strncpy(server->master_query_tag, "0.0.0.0:0", sizeof(server->master_query_tag));
 				server->master_query_tag[sizeof(server->master_query_tag) -1] = '\0';
 			}
 
@@ -5505,7 +5505,7 @@ send_gamespy_master_request(struct qserver *server)
 		return (send_error(server, rc));
 	}
 
-	strncpy(request, server->type->status_packet, sizeof(request) -1);
+	strncpy(request, server->type->status_packet, sizeof(request));
 	request[sizeof(request) -1] = '\0';
 
 	for (i = 0; gamespy_query_map[i].qstat_type; i++) {
@@ -5557,7 +5557,7 @@ send_rule_request_packet(struct qserver *server)
 	}
 
 	if (server->type->id == Q_SERVER) {
-		strncpy((char*)q_rule.data, server->next_rule, sizeof(q_rule.data) -1);
+		strncpy((char *)q_rule.data, server->next_rule, sizeof(q_rule.data));
 		q_rule.data[sizeof(q_rule.data) - 1] = '\0';
 		len = Q_HEADER_LEN + strlen((char *)q_rule.data) + 1;
 		q_rule.length = htons((short)len);
@@ -6318,7 +6318,7 @@ deal_with_q1qw_packet(struct qserver *server, char *rawpkt, int pktlen)
 					strncpy(server->error, pkt, nl - pkt);
 					server->error[nl - pkt] = '\0';
 				} else {
-					strncpy(server->error, pkt, sizeof(server->error) -1);
+					strncpy(server->error, pkt, sizeof(server->error));
 					server->error[sizeof(server->error) -1] = '\0';
 				}
 				server->server_name = SERVERERROR;
@@ -6548,7 +6548,7 @@ player_info:            debug(3, "player info");
 					strncpy(server->error, pkt, nl - pkt);
 					server->error[sizeof(server->error) -1] = '\0';
 				} else {
-					strncpy(server->error, pkt, sizeof(server->error) -1);
+					strncpy(server->error, pkt, sizeof(server->error));
 					server->error[sizeof(server->error) -1] = '\0';
 				}
 				server->server_name = SERVERERROR;
@@ -6743,8 +6743,7 @@ deal_with_qwmaster_packet(struct qserver *server, char *rawpkt, int pktlen)
 		unsigned short port = htons(*((unsigned short *)(rawpkt + pktlen - 2)));
 
 		//fprintf( stderr, "NEXT IP=%s:%u\n", ip, port );
-		snprintf(server->master_query_tag, sizeof(server->master_query_tag),
-			"%s:%u", ip, port);
+		snprintf(server->master_query_tag, sizeof(server->master_query_tag), "%s:%u", ip, port);
 
 		// skip over the 2 byte id
 		rawpkt += 2;
@@ -7328,8 +7327,7 @@ player_add_info(struct player *player, char *key, char *value, int flags)
 					fprintf(stderr, "Failed to malloc combined value\n");
 					exit(1);
 				}
-				snprintf(full_value, sizeof(full_value), "%s%s%s",
-					info->value, multi_delimiter, value);
+				snprintf(full_value, sizeof(full_value), "%s%s%s", info->value, multi_delimiter, value);
 
 				// We should be able to free this
 				free(info->value);
@@ -7403,8 +7401,7 @@ add_rule(struct qserver *server, char *key, char *value, int flags)
 					fprintf(stderr, "Failed to malloc combined value\n");
 					exit(1);
 				}
-				snprintf(full_value, sizeof(full_value), "%s%s%s",
-					rule->value, multi_delimiter, value);
+				snprintf(full_value, sizeof(full_value), "%s%s%s", rule->value, multi_delimiter, value);
 
 				// We should be able to free this
 				free(rule->value);
@@ -7511,8 +7508,7 @@ change_server_port(struct qserver *server, unsigned short port, int force)
 		unsigned int ipaddr = ntohl(server->ipaddr);
 
 		// Update the servers hostname as required
-		snprintf(arg, sizeof(arg), "%d.%d.%d.%d:%hu",
-			ipaddr >> 24, (ipaddr >> 16) &0xff, (ipaddr >> 8) &0xff, ipaddr &0xff, port);
+		snprintf(arg, sizeof(arg), "%d.%d.%d.%d:%hu", ipaddr >> 24, (ipaddr >> 16) &0xff, (ipaddr >> 8) &0xff, ipaddr &0xff, port);
 
 		if (show_game_port || force || server->flags & TF_SHOW_GAME_PORT) {
 			// Update the server arg
@@ -7539,7 +7535,7 @@ change_server_port(struct qserver *server, unsigned short port, int force)
 					*colon = '\0';
 				}
 				snprintf(hostname, sizeof(hostname), "%s:%hu",
-					server->host_name, port);
+				    server->host_name, port);
 				free(server->host_name);
 				server->host_name = hostname;
 			}
@@ -8442,7 +8438,7 @@ deal_with_tribes_packet(struct qserver *server, char *rawpkt, int pktlen)
 	server->max_players = *pkt++;
 
 	snprintf(buf, sizeof(buf), "%u",
-		(unsigned int)pkt[0] + (unsigned int)pkt[1] *256);
+	    (unsigned int)pkt[0] + (unsigned int)pkt[1] *256);
 	add_rule(server, "cpu", buf, NO_FLAGS);
 	pkt++;          /* cpu speed, lsb */
 	pkt++;          /* cpu speed, msb */
@@ -8551,7 +8547,7 @@ deal_with_tribes_packet(struct qserver *server, char *rawpkt, int pktlen)
 		pnum++;
 	}
 
-	for (t = n_teams; t; ) {
+	for (t = n_teams; t;) {
 		t--;
 		teams[t]->next = server->players;
 		server->players = teams[t];
@@ -8718,7 +8714,7 @@ deal_with_tribes2_packet(struct qserver *server, char *pkt, int pktlen)
 	pkt++;
 	server->max_players = *(unsigned char *)pkt;
 	pkt++;
-	snprintf(str, sizeof(str), "%u", *(unsigned char*)pkt);
+	snprintf(str, sizeof(str), "%u", *(unsigned char *)pkt);
 	add_rule(server, "bot_count", str, NO_FLAGS);
 	pkt++;
 	cpu_speed = swap_short_from_little(pkt);
@@ -8845,7 +8841,7 @@ deal_with_tribes2_packet(struct qserver *server, char *pkt, int pktlen)
 	}
 
 info_done:
-	for (t = n_teams; t; ) {
+	for (t = n_teams; t;) {
 		t--;
 		teams[t]->next = server->players;
 		server->players = teams[t];
@@ -8958,19 +8954,19 @@ deal_with_ghostrecon_packet(struct qserver *server, char *pkt, int pktlen)
 
 	switch (ServerVersion) {
 	case VERSION_1_2_10:
-		strncpy(str, "1.2.10", sizeof(str) -1);
+		strncpy(str, "1.2.10", sizeof(str));
 		str[sizeof(str) - 1] = '\0';
 		pkt += sizeof(Dat2Reply1_2_10);
 		break;
 
 	case VERSION_1_3:
-		strncpy(str, "1.3", sizeof(str) -1);
+		strncpy(str, "1.3", sizeof(str));
 		str[sizeof(str) - 1] = '\0';
 		pkt += sizeof(Dat2Reply1_3);
 		break;
 
 	case VERSION_1_4:
-		strncpy(str, "1.4", sizeof(str) -1);
+		strncpy(str, "1.4", sizeof(str));
 		str[sizeof(str) - 1] = '\0';
 		pkt += sizeof(Dat2Reply1_4);
 		break;
@@ -9140,22 +9136,22 @@ deal_with_ghostrecon_packet(struct qserver *server, char *pkt, int pktlen)
 
 	switch (pkt[0]) {
 	case 3:
-		strncpy(str, "Joining", sizeof(str) -1);
+		strncpy(str, "Joining", sizeof(str));
 		str[sizeof(str) -1] = '\0';
 		break;
 
 	case 4:
-		strncpy(str, "Playing", sizeof(str) -1);
+		strncpy(str, "Playing", sizeof(str));
 		str[sizeof(str) -1] = '\0';
 		break;
 
 	case 5:
-		strncpy(str, "Debrief", sizeof(str) -1);
+		strncpy(str, "Debrief", sizeof(str));
 		str[sizeof(str) -1] = '\0';
 		break;
 
 	default:
-		strncpy(str, "Undefined", sizeof(str) -1);
+		strncpy(str, "Undefined", sizeof(str));
 		str[sizeof(str) -1] = '\0';
 	}
 	add_rule(server, "status", str, NO_FLAGS);
@@ -9166,17 +9162,17 @@ deal_with_ghostrecon_packet(struct qserver *server, char *pkt, int pktlen)
 
 	switch (pkt[0]) {
 	case 2:
-		strncpy(str, "COOP", sizeof(str) -1);
+		strncpy(str, "COOP", sizeof(str));
 		str[sizeof(str) -1] = '\0';
 		break;
 
 	case 3:
-		strncpy(str, "SOLO", sizeof(str) -1);
+		strncpy(str, "SOLO", sizeof(str));
 		str[sizeof(str) -1] = '\0';
 		break;
 
 	case 4:
-		strncpy(str, "TEAM", sizeof(str) -1);
+		strncpy(str, "TEAM", sizeof(str));
 		str[sizeof(str) -1] = '\0';
 		break;
 
@@ -9214,27 +9210,27 @@ deal_with_ghostrecon_packet(struct qserver *server, char *pkt, int pktlen)
 
 	switch (iSpawnType) {
 	case 0:
-		strncpy(str, "None", sizeof(str) -1);
+		strncpy(str, "None", sizeof(str));
 		str[sizeof(str) -1] = '\0';
 		break;
 
 	case 1:
-		strncpy(str, "Individual", sizeof(str) -1);
+		strncpy(str, "Individual", sizeof(str));
 		str[sizeof(str) -1] = '\0';
 		break;
 
 	case 2:
-		strncpy(str, "Team", sizeof(str) -1);
+		strncpy(str, "Team", sizeof(str));
 		str[sizeof(str) -1] = '\0';
 		break;
 
 	case 3:
-		strncpy(str, "Infinite", sizeof(str) -1);
+		strncpy(str, "Infinite", sizeof(str));
 		str[sizeof(str) -1] = '\0';
 		break;
 
 	default:
-		strncpy(str, "Unknown", sizeof(str) -1);
+		strncpy(str, "Unknown", sizeof(str));
 		str[sizeof(str) -1] = '\0';
 	}
 
@@ -9370,11 +9366,11 @@ deal_with_ghostrecon_packet(struct qserver *server, char *pkt, int pktlen)
 
 	iTemp = pkt[0]; // Allow Observers
 	if (iTemp) {
-		strncpy(str, "Yes", sizeof(str) -1);
+		strncpy(str, "Yes", sizeof(str));
 		str[sizeof(str) -1] = '\0';
 	} else {
 		/* else not used */
-		strncpy(str, "No", sizeof(str) -1);
+		strncpy(str, "No", sizeof(str));
 		str[sizeof(str) -1] = '\0';
 	}
 	add_rule(server, "allowobservers", str, NO_FLAGS);
@@ -9395,22 +9391,22 @@ deal_with_ghostrecon_packet(struct qserver *server, char *pkt, int pktlen)
 	iTemp = pkt[0]; // IFF
 	switch (iTemp) {
 	case 0:
-		strncpy(str, "None", sizeof(str) -1);
+		strncpy(str, "None", sizeof(str));
 		str[sizeof(str) -1] = '\0';
 		break;
 
 	case 1:
-		strncpy(str, "Reticule", sizeof(str) -1);
+		strncpy(str, "Reticule", sizeof(str));
 		str[sizeof(str) -1] = '\0';
 		break;
 
 	case 2:
-		strncpy(str, "Names", sizeof(str) -1);
+		strncpy(str, "Names", sizeof(str));
 		str[sizeof(str) -1] = '\0';
 		break;
 
 	default:
-		strncpy(str, "Unknown", sizeof(str) -1);
+		strncpy(str, "Unknown", sizeof(str));
 		str[sizeof(str) -1] = '\0';
 		break;
 	}
@@ -10330,7 +10326,7 @@ deal_with_descent3_packet(struct qserver *server, char *rawpkt, int pktlen)
 		add_uchar_rule(server, "mouselook", (unsigned char)((pkt[6] & 1) > 0)); /*
 		                                                                         *                                                                         mouselook enabled */
 		snprintf(buf, sizeof(buf), "%s%s",
-			(pkt[4] &16) ? "PP" : "CS", (pkt[6] &1) ? "-ML" : "");
+		    (pkt[4] &16) ? "PP" : "CS", (pkt[6] &1) ? "-ML" : "");
 		add_rule(server, "servertype", buf, NO_FLAGS);
 
 		snprintf(buf, sizeof(buf), "%hhu", pkt[9]);
@@ -11429,13 +11425,10 @@ play_time(int seconds, int show_seconds)
 			strncat(time_string, "   ", sizeof(time_string) - 1 - strlen(time_string));
 		}
 		if ((seconds % 3600) / 60 || seconds / 3600) {
-			snprintf(time_string + strlen(time_string),
-				sizeof(time_string) - strlen(time_string),
-				fmt_minute, (seconds % 3600) / 60);
+			snprintf(time_string + strlen(time_string), sizeof(time_string) - strlen(time_string), fmt_minute, (seconds % 3600) / 60);
 		} else if (!show_seconds) {
-			snprintf(time_string + strlen(time_string),
-				sizeof(time_string) - strlen(time_string),
-				" 0m");	
+			snprintf(time_string + strlen(time_string), sizeof(time_string) - strlen(time_string),
+			    " 0m");
 		} else if (show_seconds < 2) {
 			strncat(time_string, "   ", sizeof(time_string) - 1 - strlen(time_string));
 		}
@@ -11445,10 +11438,10 @@ play_time(int seconds, int show_seconds)
 	} else if (time_format == STOPWATCH_TIME) {
 		if (show_seconds) {
 			snprintf(time_string, sizeof(time_string),
-				"%02d:%02d:%02d", seconds / 3600, (seconds % 3600) / 60, seconds % 60);
+			    "%02d:%02d:%02d", seconds / 3600, (seconds % 3600) / 60, seconds % 60);
 		} else {
 			snprintf(time_string, sizeof(time_string),
-				"%02d:%02d", seconds / 3600, (seconds % 3600) / 60);
+			    "%02d:%02d", seconds / 3600, (seconds % 3600) / 60);
 		}
 	} else {
 		snprintf(time_string, sizeof(time_string), "%d", seconds);
@@ -11525,7 +11518,7 @@ sort_players(struct qserver *server)
 	}
 
 	player = server->players;
-	for ( ; player != NULL && player->number == TRIBES_TEAM; ) {
+	for ( ; player != NULL && player->number == TRIBES_TEAM;) {
 		last_team = player;
 		player = player->next;
 	}

--- a/tee.c
+++ b/tee.c
@@ -275,10 +275,10 @@ deal_with_teemaster_packet(struct qserver *server, char *rawpkt, int rawpktlen)
 	/* legacy server list format, only ipv4 addresses */
 	if (last_char == 't') {
 		len_address_packet = 6;
-	/* normal server list format, ipv4 and ipv6 addresses */
+		/* normal server list format, ipv4 and ipv6 addresses */
 	} else if (last_char == '2') {
 		len_address_packet = 18;
-	/* bad or unknown server list format */
+		/* bad or unknown server list format */
 	} else {
 		return (PKT_ERROR);
 	}
@@ -302,7 +302,7 @@ deal_with_teemaster_packet(struct qserver *server, char *rawpkt, int rawpktlen)
 			memcpy(current, rawpkt, 6);
 			memcpy(current + 5, rawpkt + 4, 1);
 			memcpy(current + 4, rawpkt + 5, 1);
-		/* ipv4 and ipv6 server list */
+			/* ipv4 and ipv6 server list */
 		} else {
 			/* ipv4 server address */
 			if (memcmp(rawpkt, ipv4_header, len_ipv4_header) == 0) {

--- a/tf.c
+++ b/tf.c
@@ -93,19 +93,19 @@ pkt_data(struct qserver *server, char **pkt, int *rem, void *data, char *rule, i
 
 		switch (size) {
 		case 1:
-			sprintf(buf, "%hhu", *(uint8_t*)data);
+			sprintf(buf, "%hhu", *(uint8_t *)data);
 			break;
 
 		case 2:
-			sprintf(buf, "%hu", *(uint16_t*)data);
+			sprintf(buf, "%hu", *(uint16_t *)data);
 			break;
 
 		case 4:
-			sprintf(buf, "%" PRIu32, *(uint32_t*)data);
+			sprintf(buf, "%" PRIu32, *(uint32_t *)data);
 			break;
 
 		case 8:
-			sprintf(buf, "%" PRIu64, *(uint64_t*)data);
+			sprintf(buf, "%" PRIu64, *(uint64_t *)data);
 			break;
 		}
 		add_rule(server, rule, buf, 0);

--- a/tm.c
+++ b/tm.c
@@ -44,7 +44,7 @@ send_tm_request_packet(struct qserver *server)
 	}
 
 	// build the query xml
-	len = snprintf( xmlp, sizeof(xmlp), TM_XML_PREFIX );
+	len = snprintf(xmlp, sizeof(xmlp), TM_XML_PREFIX);
 
 	if ((user != NULL) && (password != NULL)) {
 		len += sprintf(xmlp + len, TM_AUTH_TEMPLATE, user, password);
@@ -229,7 +229,7 @@ deal_with_tm_packet(struct qserver *server, char *rawpkt, int pktlen)
 				} else if (0 == strcmp("CurrentMaxPlayers", key)) {
 					server->max_players = atoi(value);
 				} else {
-					snprintf( fullname, sizeof(fullname), "server.%s", key );
+					snprintf(fullname, sizeof(fullname), "server.%s", key);
 					add_rule(server, fullname, value, NO_FLAGS);
 				}
 				break;
@@ -239,7 +239,7 @@ deal_with_tm_packet(struct qserver *server, char *rawpkt, int pktlen)
 				if (0 == strcmp("Name", key)) {
 					server->map_name = strdup(value);
 				} else {
-					snprintf( fullname, sizeof(fullname), "challenge.%s", key );
+					snprintf(fullname, sizeof(fullname), "challenge.%s", key);
 					add_rule(server, fullname, value, NO_FLAGS);
 				}
 				break;

--- a/tm.c
+++ b/tm.c
@@ -44,7 +44,7 @@ send_tm_request_packet(struct qserver *server)
 	}
 
 	// build the query xml
-	len = sprintf(xmlp, TM_XML_PREFIX);
+	len = snprintf( xmlp, sizeof(xmlp), TM_XML_PREFIX );
 
 	if ((user != NULL) && (password != NULL)) {
 		len += sprintf(xmlp + len, TM_AUTH_TEMPLATE, user, password);
@@ -229,7 +229,7 @@ deal_with_tm_packet(struct qserver *server, char *rawpkt, int pktlen)
 				} else if (0 == strcmp("CurrentMaxPlayers", key)) {
 					server->max_players = atoi(value);
 				} else {
-					sprintf(fullname, "server.%s", key);
+					snprintf( fullname, sizeof(fullname), "server.%s", key );
 					add_rule(server, fullname, value, NO_FLAGS);
 				}
 				break;
@@ -239,7 +239,7 @@ deal_with_tm_packet(struct qserver *server, char *rawpkt, int pktlen)
 				if (0 == strcmp("Name", key)) {
 					server->map_name = strdup(value);
 				} else {
-					sprintf(fullname, "challenge.%s", key);
+					snprintf( fullname, sizeof(fullname), "challenge.%s", key );
 					add_rule(server, fullname, value, NO_FLAGS);
 				}
 				break;

--- a/ts2.c
+++ b/ts2.c
@@ -32,11 +32,11 @@ send_ts2_request_packet(struct qserver *server)
 
 	if (get_player_info) {
 		server->flags |= TF_PLAYER_QUERY | TF_RULES_QUERY;
-		sprintf(buf, "si %d\npl %d\nquit\n", serverport, serverport);
+		snprintf( buf, sizeof(buf), "si %d\npl %d\nquit\n", serverport, serverport );
 		server->saved_data.pkt_index = 2;
 	} else {
 		server->flags |= TF_STATUS_QUERY;
-		sprintf(buf, "si %d\nquit\n", serverport);
+		snprintf( buf, sizeof(buf), "si %d\nquit\n", serverport );
 		server->saved_data.pkt_index = 1;
 	}
 

--- a/ts2.c
+++ b/ts2.c
@@ -32,11 +32,11 @@ send_ts2_request_packet(struct qserver *server)
 
 	if (get_player_info) {
 		server->flags |= TF_PLAYER_QUERY | TF_RULES_QUERY;
-		snprintf( buf, sizeof(buf), "si %d\npl %d\nquit\n", serverport, serverport );
+		snprintf(buf, sizeof(buf), "si %d\npl %d\nquit\n", serverport, serverport);
 		server->saved_data.pkt_index = 2;
 	} else {
 		server->flags |= TF_STATUS_QUERY;
-		snprintf( buf, sizeof(buf), "si %d\nquit\n", serverport );
+		snprintf(buf, sizeof(buf), "si %d\nquit\n", serverport);
 		server->saved_data.pkt_index = 1;
 	}
 

--- a/ts3.c
+++ b/ts3.c
@@ -138,7 +138,7 @@ send_ts3_single_server_packet(struct qserver *server)
 
 	case 4:
 		// Player Info, Quit or Done
-		snprintf(buf, sizeof(buf), ( get_player_info ) ? "clientlist\015\012" : "quit\015\012");
+		snprintf(buf, sizeof(buf), (get_player_info) ? "clientlist\015\012" : "quit\015\012");
 		break;
 
 	case 5:

--- a/ts3.c
+++ b/ts3.c
@@ -66,7 +66,7 @@ send_ts3_all_servers_packet(struct qserver *server)
 		password = get_param_value(server, "password", "");
 		if (0 != strlen(password)) {
 			username = get_param_value(server, "username", "serveradmin");
-			sprintf(buf, "login %s %s\015\012", username, password);
+			snprintf( buf, sizeof(buf), "login %s %s\015\012", username, password );
 			break;
 		}
 		// NOTE: no break so we fall through
@@ -76,11 +76,11 @@ send_ts3_all_servers_packet(struct qserver *server)
 		// NOTE: we currently don't support player info
 		server->flags |= TF_STATUS_QUERY;
 		server->n_servers = 3;
-		sprintf(buf, "serverlist\015\012");
+		snprintf( buf, sizeof(buf), "serverlist\015\012" );
 		break;
 
 	case 3:
-		sprintf(buf, "quit\015\012");
+		snprintf( buf, sizeof(buf), "quit\015\012", password, username );
 		break;
 
 	case 4:
@@ -110,7 +110,7 @@ send_ts3_single_server_packet(struct qserver *server)
 		password = get_param_value(server, "password", "");
 		if (0 != strlen(password)) {
 			username = get_param_value(server, "username", "serveradmin");
-			sprintf(buf, "login %s %s\015\012", username, password);
+			snprintf( buf, sizeof(buf), "login %s %s\015\012", password, username );
 			break;
 		}
 		// NOTE: no break so we fall through
@@ -128,7 +128,7 @@ send_ts3_single_server_packet(struct qserver *server)
 			server->flags |= TF_STATUS_QUERY;
 			server->n_servers = 4;
 		}
-		sprintf(buf, "use port=%d\015\012", serverport);
+		snprintf( buf, sizeof(buf), "use port=%d\015\012" );
 		break;
 
 	case 3:
@@ -138,13 +138,13 @@ send_ts3_single_server_packet(struct qserver *server)
 
 	case 4:
 		// Player Info, Quit or Done
-		sprintf(buf, (get_player_info) ? "clientlist\015\012" : "quit\015\012");
+		snprintf( buf, sizeof(buf), ( get_player_info ) ? "clientlist\015\012" : "quit\015\012" );
 		break;
 
 	case 5:
 		// Quit or Done
 		if (get_player_info) {
-			sprintf(buf, "quit\015\012");
+			snprintf( buf, sizeof(buf), "quit\015\012" );
 		} else {
 			return (DONE_FORCE);
 		}

--- a/ts3.c
+++ b/ts3.c
@@ -66,7 +66,7 @@ send_ts3_all_servers_packet(struct qserver *server)
 		password = get_param_value(server, "password", "");
 		if (0 != strlen(password)) {
 			username = get_param_value(server, "username", "serveradmin");
-			snprintf( buf, sizeof(buf), "login %s %s\015\012", username, password );
+			snprintf(buf, sizeof(buf), "login %s %s\015\012", username, password);
 			break;
 		}
 		// NOTE: no break so we fall through
@@ -76,11 +76,11 @@ send_ts3_all_servers_packet(struct qserver *server)
 		// NOTE: we currently don't support player info
 		server->flags |= TF_STATUS_QUERY;
 		server->n_servers = 3;
-		snprintf( buf, sizeof(buf), "serverlist\015\012" );
+		snprintf(buf, sizeof(buf), "serverlist\015\012");
 		break;
 
 	case 3:
-		snprintf( buf, sizeof(buf), "quit\015\012", password, username );
+		snprintf(buf, sizeof(buf), "quit\015\012", password, username);
 		break;
 
 	case 4:
@@ -110,7 +110,7 @@ send_ts3_single_server_packet(struct qserver *server)
 		password = get_param_value(server, "password", "");
 		if (0 != strlen(password)) {
 			username = get_param_value(server, "username", "serveradmin");
-			snprintf( buf, sizeof(buf), "login %s %s\015\012", password, username );
+			snprintf(buf, sizeof(buf), "login %s %s\015\012", password, username);
 			break;
 		}
 		// NOTE: no break so we fall through
@@ -128,7 +128,7 @@ send_ts3_single_server_packet(struct qserver *server)
 			server->flags |= TF_STATUS_QUERY;
 			server->n_servers = 4;
 		}
-		snprintf( buf, sizeof(buf), "use port=%d\015\012" );
+		snprintf(buf, sizeof(buf), "use port=%d\015\012");
 		break;
 
 	case 3:
@@ -138,13 +138,13 @@ send_ts3_single_server_packet(struct qserver *server)
 
 	case 4:
 		// Player Info, Quit or Done
-		snprintf( buf, sizeof(buf), ( get_player_info ) ? "clientlist\015\012" : "quit\015\012" );
+		snprintf(buf, sizeof(buf), ( get_player_info ) ? "clientlist\015\012" : "quit\015\012");
 		break;
 
 	case 5:
 		// Quit or Done
 		if (get_player_info) {
-			snprintf( buf, sizeof(buf), "quit\015\012" );
+			snprintf(buf, sizeof(buf), "quit\015\012");
 		} else {
 			return (DONE_FORCE);
 		}

--- a/ut2004.c
+++ b/ut2004.c
@@ -82,7 +82,7 @@ static const char approved_response[] =
 static const char verified[] =
 {
 	0x0a, 0x00, 0x00, 0x00, 0x09, 'V', 'E', 'R',
-	'I',  'F',  'I',  'E',	'D', 0x00
+	'I',  'F',  'I',  'E',	'D',  0x00
 };
 
 #if 0
@@ -109,9 +109,9 @@ static char cdkey[CD_KEY_LENGTH + 1] = "";
 
 enum ut2004_state {
 	STATE_CHALLENGE = 0x00,
-	STATE_APPROVED  = 0x01,
-	STATE_VERIFIED  = 0x02,
-	STATE_LISTING   = 0x03,
+	STATE_APPROVED	= 0x01,
+	STATE_VERIFIED	= 0x02,
+	STATE_LISTING	= 0x03,
 };
 
 query_status_t

--- a/wic.c
+++ b/wic.c
@@ -33,11 +33,11 @@ send_wic_request_packet(struct qserver *server)
 
 	if (get_player_info) {
 		server->flags |= TF_PLAYER_QUERY | TF_RULES_QUERY;
-		snprintf( buf, sizeof(buf), "%s\x0d\x0a/listsettings\x0d\x0a/listplayers\x0d\x0a/exit\x0d\x0a", password );
+		snprintf(buf, sizeof(buf), "%s\x0d\x0a/listsettings\x0d\x0a/listplayers\x0d\x0a/exit\x0d\x0a", password);
 		server->saved_data.pkt_index = 2;
 	} else {
 		server->flags |= TF_STATUS_QUERY;
-		snprintf( buf, sizeof(buf), "%s\x0d\x0a/listsettings\x0d\x0a/exit\x0d\x0a", password );
+		snprintf(buf, sizeof(buf), "%s\x0d\x0a/listsettings\x0d\x0a/exit\x0d\x0a", password);
 		server->saved_data.pkt_index = 1;
 	}
 

--- a/wic.c
+++ b/wic.c
@@ -33,11 +33,11 @@ send_wic_request_packet(struct qserver *server)
 
 	if (get_player_info) {
 		server->flags |= TF_PLAYER_QUERY | TF_RULES_QUERY;
-		sprintf(buf, "%s\x0d\x0a/listsettings\x0d\x0a/listplayers\x0d\x0a/exit\x0d\x0a", password);
+		snprintf( buf, sizeof(buf), "%s\x0d\x0a/listsettings\x0d\x0a/listplayers\x0d\x0a/exit\x0d\x0a", password );
 		server->saved_data.pkt_index = 2;
 	} else {
 		server->flags |= TF_STATUS_QUERY;
-		sprintf(buf, "%s\x0d\x0a/listsettings\x0d\x0a/exit\x0d\x0a", password);
+		snprintf( buf, sizeof(buf), "%s\x0d\x0a/listsettings\x0d\x0a/exit\x0d\x0a", password );
 		server->saved_data.pkt_index = 1;
 	}
 

--- a/xform.c
+++ b/xform.c
@@ -81,15 +81,15 @@ xform_html_entity(const char c, char *dest)
 	if (html_mode) {
 		switch (c) {
 		case '<':
-			strcpy(dest, "&lt;");
+			strlcpy(dest, "&lt;", sizeof(dest));
 			return (4);
 
 		case '>':
-			strcpy(dest, "&gt;");
+			strlcpy(dest, "&gt;", sizeof(dest));
 			return (4);
 
 		case '&':
-			strcpy(dest, "&amp;");
+			strlcpy(dest, "&amp;", sizeof(dest));
 			return (5);
 
 		default:
@@ -449,7 +449,7 @@ xform_name_u2(char *string, struct qserver *server)
 			// { '#', 'F', '8', '4', '0', '4', '0', 0x00 }
 			char color[8];
 			s += 1;
-			sprintf(color, "#%02hhx%02hhx%02hhx", s[0], s[1], s[2]);
+			snprintf(color, sizeof(color), "#%02hhx%02hhx%02hhx", s[0], s[1], s[2]);
 			q += xform_html_color(&q, color);
 			s += 3;
 		} else {
@@ -702,7 +702,7 @@ xform_name(char *string, struct qserver *server)
 
 	if (string == NULL) {
 		buf = xform_buf_get(1);
-		strcpy(buf, "?");
+		strlcpy(buf, "?", sizeof(buf));
 
 		return (buf);
 	}
@@ -725,7 +725,7 @@ xform_name(char *string, struct qserver *server)
 		*bufp = '\0';
 
 		if (*buf == '\0') {
-			strcpy(buf, "?");
+			strlcpy(buf, "?", sizeof(buf));
 			return (buf);
 		}
 		s = buf;
@@ -737,7 +737,7 @@ xform_name(char *string, struct qserver *server)
 		buf = xform_buf_get(strlen(s) * 2);
 		bufp = buf;
 		for ( ; *s; s++, bufp += 2) {
-			sprintf(bufp, "%02hhx", *s);
+			snprintf(bufp, sizeof(bufp), "%02hhx", *s);
 		}
 		*bufp = '\0';
 

--- a/xform.c
+++ b/xform.c
@@ -81,17 +81,17 @@ xform_html_entity(const char c, char *dest)
 	if (html_mode) {
 		switch (c) {
 		case '<':
-			strncpy(dest, "&lt;", sizeof(dest) - 1);
+			strncpy(dest, "&lt;", sizeof(dest));
 			dest[sizeof(dest) -1] = '\0';
 			return (4);
 
 		case '>':
-			strncpy(dest, "&gt;", sizeof(dest) - 1);
+			strncpy(dest, "&gt;", sizeof(dest));
 			dest[sizeof(dest) -1] = '\0';
 			return (4);
 
 		case '&':
-			strncpy(dest, "&amp;", sizeof(dest) - 1);
+			strncpy(dest, "&amp;", sizeof(dest));
 			dest[sizeof(dest) -1] = '\0';
 			return (5);
 
@@ -705,7 +705,7 @@ xform_name(char *string, struct qserver *server)
 
 	if (string == NULL) {
 		buf = xform_buf_get(1);
-		strncpy(buf, "?", sizeof(buf) -1);
+		strncpy(buf, "?", sizeof(buf));
 		buf[sizeof(buf) - 1] = '\0';
 
 		return (buf);
@@ -729,7 +729,7 @@ xform_name(char *string, struct qserver *server)
 		*bufp = '\0';
 
 		if (*buf == '\0') {
-			strncpy(buf, "?", sizeof(buf) - 1);
+			strncpy(buf, "?", sizeof(buf));
 			buf[sizeof(buf) - 1] = '\0';
 			return (buf);
 		}

--- a/xform.c
+++ b/xform.c
@@ -81,15 +81,18 @@ xform_html_entity(const char c, char *dest)
 	if (html_mode) {
 		switch (c) {
 		case '<':
-			strlcpy(dest, "&lt;", sizeof(dest));
+			strncpy(dest, "&lt;", sizeof(dest) - 1);
+			dest[sizeof(dest) -1] = '\0';
 			return (4);
 
 		case '>':
-			strlcpy(dest, "&gt;", sizeof(dest));
+			strncpy(dest, "&gt;", sizeof(dest) - 1);
+			dest[sizeof(dest) -1] = '\0';
 			return (4);
 
 		case '&':
-			strlcpy(dest, "&amp;", sizeof(dest));
+			strncpy(dest, "&amp;", sizeof(dest) - 1);
+			dest[sizeof(dest) -1] = '\0';
 			return (5);
 
 		default:
@@ -702,7 +705,8 @@ xform_name(char *string, struct qserver *server)
 
 	if (string == NULL) {
 		buf = xform_buf_get(1);
-		strlcpy(buf, "?", sizeof(buf));
+		strncpy(buf, "?", sizeof(buf) -1);
+		buf[sizeof(buf) - 1] = '\0';
 
 		return (buf);
 	}
@@ -725,7 +729,8 @@ xform_name(char *string, struct qserver *server)
 		*bufp = '\0';
 
 		if (*buf == '\0') {
-			strlcpy(buf, "?", sizeof(buf));
+			strncpy(buf, "?", sizeof(buf) - 1);
+			buf[sizeof(buf) - 1] = '\0';
 			return (buf);
 		}
 		s = buf;


### PR DESCRIPTION
OK here's a pretty big pull request. I rewrote many of the strings functions to help prevent overflows. There are still some using the older functions that did pointer arithmetic that I didn't feel comfortable changing.
I tested all the Quake 1 servers as mentioned in Issue #12  and none of them do a buffer overflow, however I think this will need quite a bit of testing.