### PR TITLE
remove tremfusion (tremulous does the thing)

### DIFF
--- a/qstat.cfg
+++ b/qstat.cfg
@@ -277,20 +277,6 @@ gametype TREMULOUSGPPM new extend Q3M
     master for gametype = TREMULOUSGPPS
 end
 
-# id Tech 3 fork (Tremulous engine derivative, Quake 3 derivative)
-gametype TREMFUSIONS new extend Q3S
-    name = TremFusion
-    template var = TREMFUSIONS
-    game rule = gamename
-end
-gametype TREMFUSIONM new extend Q3M
-    name = TremFusion Master
-    template var = TREMFUSIONMASTER
-    default port = 30710
-    master protocol = 69
-    master for gametype = TREMFUSIONS
-end
-
 # id Tech 3 fork (Daemon engine, Quake 3 derivative, via Tremulous, ioquake3, XreaL, ioWolfET)
 gametype UNVANQUISHEDS new extend Q3S
     name = Unvanquished


### PR DESCRIPTION
TremFusion was a project aimed to improve the tremulous client,
the TremFusion is dead since years and people who still use their
binaries (either as client or server) today just use it as
alternative binaries for the same game, using the same protocol
and same ports etc. There is no reason to keep two entries that
does the same thing. We can see TremFusion as an alternative build
of the same Tremulous game. And since the project is dead and six
feets under, this will never change.

The -tremulouss and -tremulousm options do the thing very well.