### PR TITLE
fix sneaky mistake in qstat.cfg, make travis check for its validity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 before_script:
   - ./autogen.sh
 script:
-  - ./configure && make
+  - ./configure && make && ./qstat -cfg qstat.cfg -h
 compiler:
   - clang
   - gcc

--- a/qstat.cfg
+++ b/qstat.cfg
@@ -487,6 +487,7 @@ end
 gametype TF2 new extend TF
    name = Titanfall 2
    status packet = \x4d
+end
 
 # id Tech 2 fork (Quetoo engine, Quake 2 derivative)
 gametype QUETOOS new extend Q2S


### PR DESCRIPTION
It looks like I hit a sneaky merge issue while rebasing #75 on master…

I updated Travis config file to make it test the validity of `qstat.cfg` after having successfully built `qstat`.