### PR TITLE
Made Titanfall 2 protocol v2 backwards compatible

### DIFF
--- a/qstat.cfg
+++ b/qstat.cfg
@@ -500,5 +500,10 @@ end
 
 gametype TF2 new extend TF
    name = Titanfall 2
-   status packet = \x4d
+   status packet = \xff\xff\xff\xff\x4f\x03
+end
+
+gametype TF2E new extend TF
+   name = Titanfall 2 Protocol v2
+   status packet = \xff\xff\xff\xff\x4d\x03
 end

--- a/tf.c
+++ b/tf.c
@@ -21,9 +21,10 @@
 #include <inttypes.h>
 #include <string.h>
 
+#define SERVERINFO_REQUEST_PAD		77
 #define SERVERINFO_REQUEST		79
 #define SERVERINFO_RESPONSE		80
-#define SERVERINFO_VERSION		3
+#define SERVERINFO_VERSION		1
 #define SERVERINFO_VERSION_KEYED	4
 #define TEAM_IMC			"imc"
 #define TEAM_MILITIA			"militia"
@@ -154,9 +155,12 @@ send_tf_request_packet(struct qserver *server)
 	len = sizeof(serverinfo_pkt);
 	if (server->type->status_packet != NULL) {
 		// Custom packet type
-		buf[4] = server->type->status_packet[0];
-		// None standard packet types require the packet to be padded.
-		len = sizeof(buf);
+		len = server->type->status_len;
+		memcpy(buf, server->type->status_packet, len);
+
+		if (buf[4] == SERVERINFO_REQUEST_PAD) {
+			len = sizeof(buf);
+		}
 	}
 	key = get_param_value(server, "key", NULL);
 	if (key != NULL) {


### PR DESCRIPTION
In order to ensure the new Titanfall 2 protocol v2 is backwards compatible, use the full status packet definition from qstat.cfg.