### PR TITLE
Added .obj and .pdb files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,7 @@ Makefile
 gnuconfig.h
 stamp-h1
 *.o
+*.obj
+*.pdb
 qstat
 qstat.exe


### PR DESCRIPTION
We don't want windows build files committed so add them to .gitignore.