### PR TITLE
qstat: fix build failure against gcc-10

### DIFF
--- a/debug.c
+++ b/debug.c
@@ -127,7 +127,7 @@ malformed_packet(const struct qserver *server, const char *fmt, ...)
 		close(fd);
 	}
 
-
+	int do_dump;
 	ssize_t
 	send_dump(int s, const void *buf, size_t len, int flags)
 	{

--- a/debug.h
+++ b/debug.h
@@ -48,7 +48,7 @@ void dump_packet(const char *buf, int buflen);
  #endif
  #include <sys/types.h>
  #include <sys/stat.h>
-	int do_dump;
+	extern int do_dump;
 	ssize_t send_dump(int s, const void *buf, size_t len, int flags);
 
  #ifndef QSTAT_DEBUG_C

--- a/display_json.h
+++ b/display_json.h
@@ -19,9 +19,9 @@
 #include "qstat.h"
 #include "qserver.h"
 
-int json_display;
-int json_encoding;
-int json_printed;
+extern int json_display;
+extern int json_encoding;
+extern int json_printed;
 
 void json_footer();
 void json_header();


### PR DESCRIPTION
On gcc-10 (and gcc-9 -fno-common) build fails as:

```
gcc ... -o qstat ...
ld: config.o:qstat/display_json.h:24:
  multiple definition of `json_printed'; xform.o:qstat/display_json.h:24: first defined here
ld: config.o:qstat/display_json.h:23:
  multiple definition of `json_encoding'; xform.o:qstat/display_json.h:23: first defined here
```

gcc-10 will change the default from -fcommon to fno-common:
https://gcc.gnu.org/PR85678.

The error also happens if CFLAGS=-fno-common passed explicitly.

Reported-by: Toralf Förster
Bug: https://bugs.gentoo.org/706390