### PR TITLE
feat: Enable tf query args

### DIFF
--- a/qstat.h
+++ b/qstat.h
@@ -3689,7 +3689,7 @@ server_type *find_server_type_string(char *type_string);
 			0,                              /* master */
 			0,                              /* default_port */
 			0,                              /* port_offset */
-			0,                              /* flags */
+			TF_QUERY_ARG,                   /* flags */
 			"game_mode",                    /* game_rule */
 			"TFPROTOCOL",                   /* template_var */
 			NULL,                           /* status_packet */


### PR DESCRIPTION
This enables query arg params to be parsed from host file as well as directly on the command line.