### PR TITLE
fix(ut2004): cdkey file detection on Windows

### DIFF
--- a/ut2004.c
+++ b/ut2004.c
@@ -131,7 +131,7 @@ send_ut2004master_request_packet(struct qserver *server)
 			return (PKT_ERROR);
 		}
 
-		if (*param == '/') {
+		if (strstr(param, "/") != NULL || strstr(param, "\\") != NULL) {
 			FILE *fp = fopen(param, "r");
 			if (!fp || (fread(cdkey, 1, CD_KEY_LENGTH, fp) != CD_KEY_LENGTH)) {
 				debug(0, "Error: can't key from %s", param);


### PR DESCRIPTION
Fix the file detection method used by ut2004 to support Windows paths as well as Unix paths.

Fixes #96 