### PR TITLE
fix(hexen2): player details

### DIFF
--- a/qserver.h
+++ b/qserver.h
@@ -220,6 +220,11 @@ int register_send(struct qserver *server);
 query_status_t send_packet(struct qserver *server, const char *data, size_t len);
 
 /**
+ * Sends a packet to the server either direct or via broadcast.
+ */
+query_status_t send_packet_raw(struct qserver *server, const char *data, size_t len);
+
+/**
  * Logs the error from a socket send
  */
 query_status_t send_error(struct qserver *server, int rc);


### PR DESCRIPTION
Fix Hexen 2 player details by enabling next_player_info flow.

Also:
* Extract code send code into send_packet_raw and use in all send methods. This enables easy conversion of callers using send(...)  to use a version which supports packet debugging.